### PR TITLE
refactor: harden script generation fallbacks

### DIFF
--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -86,6 +86,12 @@ class CrewConfig(BaseModel):
     verbose: bool = False
 
 
+class ScriptGenerationConfig(BaseModel):
+    """Script generation feature flags."""
+
+    quality_gate_llm_enabled: bool = True
+
+
 class MediaQAGatingConfig(BaseModel):
     """QAゲートの挙動設定"""
 
@@ -200,6 +206,7 @@ class AppSettings(BaseModel):
     video_review: VideoReviewConfig = Field(default_factory=VideoReviewConfig)
     media_quality: MediaQAConfig = Field(default_factory=MediaQAConfig)
     gemini_models: GeminiModelConfig = Field(default_factory=GeminiModelConfig)
+    script_generation: ScriptGenerationConfig = Field(default_factory=ScriptGenerationConfig)
 
     # Google Drive/Sheets settings (for backward compatibility)
     google_sheet_id: Optional[str] = None
@@ -307,6 +314,11 @@ class AppSettings(BaseModel):
             config["media_quality"] = MediaQAConfig(**config["media_quality"])
         else:
             config["media_quality"] = MediaQAConfig()
+
+        if "script_generation" in config:
+            config["script_generation"] = ScriptGenerationConfig(**config["script_generation"])
+        else:
+            config["script_generation"] = ScriptGenerationConfig()
 
         # pydantic expects the quality field, but yaml has quality_thresholds
         if "quality_thresholds" in config:

--- a/app/logging_config.py
+++ b/app/logging_config.py
@@ -1,7 +1,10 @@
+import json
 import logging
 import os
-from datetime import datetime
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any, Dict, Iterable, Optional
 
 import requests
 
@@ -10,6 +13,79 @@ DISCORD_WEBHOOK = os.getenv("DISCORD_WEBHOOK_URL")
 # Define common log format and date format
 LOG_FORMAT = "[%(asctime)s] %(levelname)-8s %(name)s | %(message)s"
 DATE_FORMAT = "%H:%M:%S"
+
+_STANDARD_LOG_RECORD_FIELDS: Iterable[str] = {
+    "name",
+    "msg",
+    "args",
+    "levelname",
+    "levelno",
+    "pathname",
+    "filename",
+    "module",
+    "exc_info",
+    "exc_text",
+    "stack_info",
+    "lineno",
+    "funcName",
+    "created",
+    "msecs",
+    "relativeCreated",
+    "thread",
+    "threadName",
+    "processName",
+    "process",
+    "message",
+    "asctime",
+    "session_id",
+    "run_id",
+}
+
+
+def _utcnow_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _safe_json(value: Any) -> Any:
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    if isinstance(value, (list, tuple)):
+        return [_safe_json(item) for item in value]
+    if isinstance(value, dict):
+        return {str(k): _safe_json(v) for k, v in value.items()}
+    return str(value)
+
+
+class JsonLineFormatter(logging.Formatter):
+    """Serialize log records as JSON for structured storage."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        base: Dict[str, Any] = {
+            "timestamp": datetime.fromtimestamp(record.created, timezone.utc).isoformat(),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+            "session_id": getattr(record, "session_id", None),
+            "run_id": getattr(record, "run_id", None),
+        }
+
+        if record.exc_info:
+            base["exception"] = self.formatException(record.exc_info)
+
+        for attr in ("event", "step", "status", "duration", "agent", "task", "api", "metric"):
+            value = getattr(record, attr, None)
+            if value is not None:
+                base[attr] = _safe_json(value)
+
+        extras = {
+            key: value
+            for key, value in record.__dict__.items()
+            if key not in _STANDARD_LOG_RECORD_FIELDS and not key.startswith("_")
+        }
+        if extras:
+            base["extra"] = {key: _safe_json(value) for key, value in extras.items()}
+
+        return json.dumps(base, ensure_ascii=False)
 
 
 class DiscordHandler(logging.Handler):
@@ -21,7 +97,8 @@ class DiscordHandler(logging.Handler):
                 return
 
             run_id = getattr(record, "run_id", "") or "-"
-            short_id = run_id[:4] if run_id else "----"
+            session_id = getattr(record, "session_id", "") or "-"
+            short_id = run_id[:4] if run_id and run_id != "-" else session_id[:4]
             msg = ""
 
             if record.levelno >= logging.ERROR:
@@ -34,7 +111,6 @@ class DiscordHandler(logging.Handler):
                 msg = f"⚠️ Warning {short_id} {summary}"
 
             elif record.levelno == logging.INFO and "Success" in record.getMessage():
-                # 例: logger.info("Success run_id url 7m32s")
                 parts = record.getMessage().split()
                 if len(parts) >= 4:
                     msg = f"✅ Success {parts[1][:4]} ({parts[-1]}) {parts[2]}"
@@ -46,105 +122,240 @@ class DiscordHandler(logging.Handler):
             self.handleError(record)
 
 
+class RunContextFilter(logging.Filter):
+    """Inject session/run identifiers into every log record."""
+
+    def __init__(self, session_id: str) -> None:
+        super().__init__()
+        self.session_id = session_id
+        self.run_id: Optional[str] = None
+        self.context: Dict[str, Any] = {}
+
+    def set_context(self, run_id: Optional[str] = None, **context: Any) -> None:
+        self.run_id = run_id or self.run_id
+        self.context.update({k: v for k, v in context.items() if v is not None})
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        if not hasattr(record, "session_id"):
+            record.session_id = self.session_id
+        if self.run_id and not hasattr(record, "run_id"):
+            record.run_id = self.run_id
+        for key, value in self.context.items():
+            if not hasattr(record, key):
+                setattr(record, key, value)
+        return True
+
+
+@dataclass
+class LoggingSession:
+    """Holds metadata about the current logging session."""
+
+    session_id: str
+    base_dir: Path
+    run_dir: Path
+    text_log_path: Path
+    error_log_path: Path
+    structured_log_path: Path
+    metadata_path: Path
+    created_at: str = field(default_factory=_utcnow_iso)
+    _filter: Optional[RunContextFilter] = field(default=None, repr=False)
+
+    def initialize_metadata(self, log_level: int) -> None:
+        payload = {
+            "session_id": self.session_id,
+            "created_at": self.created_at,
+            "log_level": logging.getLevelName(log_level),
+            "paths": {
+                "text": str(self.text_log_path),
+                "errors": str(self.error_log_path),
+                "structured": str(self.structured_log_path),
+            },
+        }
+        self.metadata_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+
+    def attach_filter(self, filter_: RunContextFilter) -> None:
+        self._filter = filter_
+
+    def bind_workflow_run(self, run_id: str, mode: Optional[str] = None) -> None:
+        self._update_metadata({"workflow_run_id": run_id, "mode": mode})
+        if self._filter:
+            self._filter.set_context(run_id=run_id, mode=mode)
+
+    def mark_status(self, status: str, **fields: Any) -> None:
+        payload = {"status": status, "updated_at": _utcnow_iso()}
+        payload.update({k: _safe_json(v) for k, v in fields.items()})
+        self._update_metadata(payload)
+
+    def _update_metadata(self, updates: Dict[str, Any]) -> None:
+        if self.metadata_path.exists():
+            current = json.loads(self.metadata_path.read_text(encoding="utf-8"))
+        else:
+            current = {}
+        current.update({k: v for k, v in updates.items() if v is not None})
+        self.metadata_path.write_text(json.dumps(current, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+_CURRENT_SESSION: Optional[LoggingSession] = None
+
+
+def get_log_session() -> Optional[LoggingSession]:
+    """Return the active logging session, if any."""
+
+    return _CURRENT_SESSION
+
+
 class WorkflowLogger:
     """ワークフロー専用のログヘルパー"""
 
-    def __init__(self, name):
+    def __init__(self, name: str):
         self.logger = logging.getLogger(name)
 
-    def step_start(self, step_name, details=""):
+    def step_start(self, step_name: str, details: str = "") -> None:
         """ステップ開始ログ"""
-        self.logger.info(f"{ '='*60}")
-        self.logger.info(f"▶ STEP: {step_name}")
-        if details:
-            self.logger.info(f"  Details: {details}")
-        self.logger.info(f"{ '='*60}")
 
-    def step_end(self, step_name, duration=None, status="SUCCESS"):
+        message = f"Starting workflow step: {step_name}"
+        if details:
+            message += f" ({details})"
+        self.logger.info(message, extra={"event": "step_start", "step": step_name, "details": details})
+
+    def step_end(self, step_name: str, duration: Optional[float] = None, status: str = "SUCCESS") -> None:
         """ステップ終了ログ"""
-        emoji = "✅" if status == "SUCCESS" else "❌"
-        msg = f"{emoji} {step_name} completed"
-        if duration:
-            msg += f" ({duration:.2f}s)"
-        self.logger.info(msg)
-        self.logger.info(f"{ '='*60}\n")
 
-    def agent_start(self, agent_name, task_name):
+        emoji = "✅" if status.upper() == "SUCCESS" else "❌"
+        suffix = f" ({duration:.2f}s)" if duration is not None else ""
+        self.logger.info(
+            f"{emoji} Step {step_name} completed{suffix}",
+            extra={"event": "step_end", "step": step_name, "status": status, "duration": duration},
+        )
+
+    def agent_start(self, agent_name: str, task_name: str) -> None:
         """エージェント実行開始"""
-        self.logger.info(f"🤖 Agent [{agent_name}] starting task: {task_name}")
 
-    def agent_end(self, agent_name, output_length=0, status="SUCCESS"):
+        self.logger.info(
+            f"🤖 Agent [{agent_name}] starting task: {task_name}",
+            extra={"event": "agent_start", "agent": agent_name, "task": task_name},
+        )
+
+    def agent_end(self, agent_name: str, output_length: int = 0, status: str = "SUCCESS") -> None:
         """エージェント実行終了"""
-        emoji = "✅" if status == "SUCCESS" else "❌"
-        self.logger.info(f"{emoji} Agent [{agent_name}] completed (output: {output_length} chars)")
 
-    def api_call(self, api_name, method="", status=""):
+        emoji = "✅" if status.upper() == "SUCCESS" else "❌"
+        self.logger.info(
+            f"{emoji} Agent [{agent_name}] completed (output: {output_length} chars)",
+            extra={
+                "event": "agent_end",
+                "agent": agent_name,
+                "status": status,
+                "output_length": output_length,
+            },
+        )
+
+    def api_call(self, api_name: str, method: str = "", status: str = "") -> None:
         """API呼び出しログ"""
+
+        message = f"🌐 API [{api_name}] {method}".strip()
         if status:
-            self.logger.debug(f"🌐 API [{api_name}] {method} -> {status}")
-        else:
-            self.logger.debug(f"🌐 API [{api_name}] {method}")
+            message += f" -> {status}"
+        self.logger.debug(
+            message,
+            extra={"event": "api_call", "api": api_name, "method": method, "status": status},
+        )
 
-    def validation(self, item_name, result, details=""):
+    def validation(self, item_name: str, result: bool, details: str = "") -> None:
         """検証結果ログ"""
+
         emoji = "✅" if result else "❌"
-        msg = f"{emoji} Validation [{item_name}]: {result}"
+        message = f"{emoji} Validation [{item_name}]: {result}"
         if details:
-            msg += f" - {details}"
-        self.logger.info(msg)
+            message += f" - {details}"
+        self.logger.info(
+            message,
+            extra={"event": "validation", "item": item_name, "result": result, "details": details},
+        )
 
-    def metric(self, metric_name, value):
+    def metric(self, metric_name: str, value: Any) -> None:
         """メトリクスログ"""
-        self.logger.info(f"📊 Metric [{metric_name}]: {value}")
 
-    def progress(self, current, total, item=""):
+        self.logger.info(
+            f"📊 Metric [{metric_name}]: {value}",
+            extra={"event": "metric", "metric": metric_name, "value": value},
+        )
+
+    def progress(self, current: int, total: int, item: str = "") -> None:
         """進捗ログ"""
+
         percentage = (current / total * 100) if total > 0 else 0
         bar = "█" * int(percentage / 5) + "░" * (20 - int(percentage / 5))
-        self.logger.info(f"⏳ Progress [{bar}] {percentage:.1f}% ({current}/{total}) {item}")
+        self.logger.info(
+            f"⏳ Progress [{bar}] {percentage:.1f}% ({current}/{total}) {item}",
+            extra={
+                "event": "progress",
+                "current": current,
+                "total": total,
+                "item": item,
+                "percentage": percentage,
+            },
+        )
 
 
-def setup_logging(log_level=logging.INFO, log_dir="logs"):
-    """
-    詳細ログシステムのセットアップ
+def setup_logging(log_level: int = logging.INFO, log_dir: str = "logs", session_id: Optional[str] = None) -> LoggingSession:
+    """詳細ログシステムのセットアップ"""
 
-    Args:
-        log_level: ログレベル (DEBUG, INFO, WARNING, ERROR)
-        log_dir: ログファイル保存ディレクトリ
-    """
-    # ログディレクトリ作成
-    log_path = Path(log_dir)
-    log_path.mkdir(exist_ok=True)
+    base_dir = Path(log_dir)
+    base_dir.mkdir(parents=True, exist_ok=True)
+    runs_dir = base_dir / "runs"
+    runs_dir.mkdir(exist_ok=True)
 
-    # ルートロガー取得
+    generated_id = session_id or f"session_{datetime.now(timezone.utc).strftime('%Y%m%d_%H%M%S')}"
+    run_dir = runs_dir / generated_id
+    run_dir.mkdir(exist_ok=True)
+
+    session = LoggingSession(
+        session_id=generated_id,
+        base_dir=base_dir,
+        run_dir=run_dir,
+        text_log_path=run_dir / "workflow.log",
+        error_log_path=run_dir / "errors.log",
+        structured_log_path=run_dir / "events.jsonl",
+        metadata_path=run_dir / "metadata.json",
+    )
+
+    session.text_log_path.touch(exist_ok=True)
+    session.error_log_path.touch(exist_ok=True)
+    session.structured_log_path.touch(exist_ok=True)
+
     root_logger = logging.getLogger()
     root_logger.setLevel(log_level)
-
-    # 既存のハンドラーをクリア
     root_logger.handlers.clear()
 
-    # コンソールハンドラー
     console_handler = logging.StreamHandler()
     console_handler.setLevel(log_level)
     console_handler.setFormatter(logging.Formatter(LOG_FORMAT, datefmt=DATE_FORMAT))
-    root_logger.addHandler(console_handler)
 
-    # ファイルハンドラー（詳細）
-    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-    file_handler = logging.FileHandler(log_path / f"workflow_{timestamp}.log", encoding="utf-8")
+    file_handler = logging.FileHandler(session.text_log_path, encoding="utf-8")
     file_handler.setLevel(logging.DEBUG)
     file_handler.setFormatter(logging.Formatter(LOG_FORMAT, datefmt=DATE_FORMAT))
-    root_logger.addHandler(file_handler)
 
-    # エラー専用ログ
-    error_handler = logging.FileHandler(log_path / "errors.log", encoding="utf-8")
+    error_handler = logging.FileHandler(session.error_log_path, encoding="utf-8")
     error_handler.setLevel(logging.ERROR)
     error_handler.setFormatter(logging.Formatter(LOG_FORMAT, datefmt=DATE_FORMAT))
-    root_logger.addHandler(error_handler)
 
-    # Discordハンドラーを追加
+    structured_handler = logging.FileHandler(session.structured_log_path, encoding="utf-8")
+    structured_handler.setLevel(logging.DEBUG)
+    structured_handler.setFormatter(JsonLineFormatter())
+
     discord_handler = DiscordHandler()
-    discord_handler.setLevel(logging.WARNING)  # WARNING以上のログをDiscordに送る
-    root_logger.addHandler(discord_handler)
+    discord_handler.setLevel(logging.WARNING)
 
-    return root_logger
+    for handler in (console_handler, file_handler, error_handler, structured_handler, discord_handler):
+        root_logger.addHandler(handler)
+
+    context_filter = RunContextFilter(session.session_id)
+    root_logger.addFilter(context_filter)
+    session.attach_filter(context_filter)
+    session.initialize_metadata(log_level)
+
+    global _CURRENT_SESSION
+    _CURRENT_SESSION = session
+
+    return session

--- a/app/services/script/speakers.py
+++ b/app/services/script/speakers.py
@@ -8,7 +8,6 @@ from typing import Dict, Iterable, List, Optional
 
 from app.config.settings import SpeakerConfig, settings
 
-
 LEGACY_SPEAKER_ALIASES: Dict[str, str] = {"田中": "武宏", "鈴木": "つむぎ", "司会": "ナレーター"}
 
 
@@ -21,6 +20,10 @@ class SpeakerRegistry:
     @property
     def canonical_names(self) -> List[str]:
         return list(self.voice_configs.keys())
+
+    @property
+    def fallback_speaker(self) -> Optional[str]:
+        return next(iter(self.voice_configs), None)
 
     @property
     def alias_map(self) -> Dict[str, str]:
@@ -58,6 +61,12 @@ class SpeakerRegistry:
         if canonical and canonical in self.voice_configs:
             return self.voice_configs[canonical]
         return None
+
+    def resolve_voice_target(self, speaker: Optional[str]) -> Optional[str]:
+        canonical = self.canonicalize(speaker)
+        if canonical in self.voice_configs:
+            return canonical
+        return self.fallback_speaker
 
 
 @lru_cache(maxsize=1)

--- a/app/services/script/validator.py
+++ b/app/services/script/validator.py
@@ -7,7 +7,6 @@ from typing import Any, Dict, List, Optional, Sequence
 
 from pydantic import BaseModel, Field, model_validator
 
-from app.config.settings import settings
 from app.services.script.speakers import get_speaker_registry
 
 _DIALOGUE_PREFIX_PATTERN = re.compile(r"[：:\-―ー\s　]*")

--- a/app/workflow/steps.py
+++ b/app/workflow/steps.py
@@ -3,7 +3,6 @@
 Each step encapsulates a single responsibility from the original YouTubeWorkflow class.
 """
 
-import json
 import logging
 import os
 from datetime import datetime
@@ -17,6 +16,7 @@ from app.search_news import collect_news
 from app.services.file_archival import FileArchivalManager
 from app.services.media import MediaQAPipeline
 from app.services.script import ScriptFormatError, ensure_dialogue_structure
+from app.services.script.validator import Script
 from app.services.video_review import get_video_review_service
 from app.services.visual_design import create_unified_design
 from app.sheets import load_prompts as load_prompts_from_sheets
@@ -24,7 +24,6 @@ from app.sheets import sheets_manager
 from app.stt import transcribe_long_audio
 from app.thumbnail import generate_thumbnail
 from app.tts import synthesize_script
-from app.services.script.validator import Script
 from app.utils import FileUtils
 from app.video import generate_video
 from app.youtube import upload_video as youtube_upload

--- a/config.yaml
+++ b/config.yaml
@@ -7,6 +7,9 @@
 gemini_models:
   default: gemini-2.5-flash-preview-09-2025
 
+script_generation:
+  quality_gate_llm_enabled: true
+
 # ============================================
 # 話者設定 (VOICEVOX対応)
 # ============================================

--- a/scripts/analyze_logs.py
+++ b/scripts/analyze_logs.py
@@ -1,88 +1,221 @@
-#!/usr/bin/env python3
-"""
-ログファイルを解析して統計情報を表示
-"""
+"""ログファイルを解析して統計情報を表示"""
 
-import re
+import json
+import sys
 from collections import defaultdict
 from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Tuple
 
 
-def analyze_log(log_file):
-    """ログファイルを解析"""
+def _load_metadata_from_structured(structured_path: Path) -> Dict[str, object]:
+    metadata_file = structured_path.with_name("metadata.json")
+    if metadata_file.exists():
+        try:
+            return json.loads(metadata_file.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            pass
+    return {}
 
+
+def _discover_latest_structured(log_dir: Path) -> Optional[Path]:
+    runs_dir = log_dir / "runs"
+    if not runs_dir.exists():
+        return None
+    candidates = sorted(runs_dir.glob("*/events.jsonl"), key=lambda p: p.stat().st_mtime)
+    return candidates[-1] if candidates else None
+
+
+def _discover_latest_text(log_dir: Path) -> Optional[Path]:
+    runs_dir = log_dir / "runs"
+    candidates: List[Path] = []
+    if runs_dir.exists():
+        candidates.extend(runs_dir.glob("*/workflow.log"))
+    candidates.extend(log_dir.glob("workflow_*.log"))
+    if not candidates:
+        return None
+    candidates.sort(key=lambda p: p.stat().st_mtime)
+    return candidates[-1]
+
+
+def analyze_structured_log(structured_path: Path) -> Dict[str, object]:
     stats = {
         "steps": [],
         "agents": defaultdict(lambda: {"success": 0, "failed": 0}),
         "api_calls": defaultdict(int),
         "errors": [],
-        "durations": {},
+        "metadata": _load_metadata_from_structured(structured_path),
     }
 
-    with open(log_file, "r", encoding="utf-8") as f:
-        for line in f:
-            # ステップ検出
-            if "▶ STEP:" in line:
-                step = line.split("STEP:")[1].strip()
-                stats["steps"].append(step)
+    with structured_path.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
 
-            # エージェント検出
-            if "🤖 Agent" in line:
-                match = re.search(r"Agent \[(.+?)\]", line)
-                if match:
-                    agent = match.group(1)
-                    if "✅" in line:
+            level = event.get("level")
+            if level == "ERROR":
+                stats["errors"].append(event.get("message"))
+
+            event_type = event.get("event")
+            if event_type == "step_end":
+                stats["steps"].append(
+                    {
+                        "name": event.get("step"),
+                        "status": (event.get("status") or "").upper(),
+                        "duration": event.get("duration"),
+                    }
+                )
+            elif event_type == "agent_end":
+                agent = event.get("agent")
+                status = (event.get("status") or "").upper()
+                if agent:
+                    if status == "SUCCESS":
                         stats["agents"][agent]["success"] += 1
-                    elif "❌" in line:
+                    else:
                         stats["agents"][agent]["failed"] += 1
-
-            # API呼び出し
-            if "🌐 API" in line:
-                match = re.search(r"API \[(.+?)\]", line)
-                if match:
-                    stats["api_calls"][match.group(1)] += 1
-
-            # エラー検出
-            if "ERROR" in line:
-                stats["errors"].append(line.strip())
-
-            # 所要時間
-            if "completed (" in line:
-                match = re.search(r"(.+?) completed \((.+?)s\)", line)
-                if match:
-                    stats["durations"][match.group(1)] = float(match.group(2))
+            elif event_type == "api_call":
+                api_name = event.get("api")
+                if api_name:
+                    stats["api_calls"][api_name] += 1
 
     return stats
 
 
-def print_summary(stats):
-    """統計サマリーを表示"""
+def analyze_text_log(log_file: Path) -> Dict[str, object]:
+    stats = {
+        "steps": [],
+        "agents": defaultdict(lambda: {"success": 0, "failed": 0}),
+        "api_calls": defaultdict(int),
+        "errors": [],
+        "metadata": {},
+    }
+
+    with log_file.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            if "▶ STEP:" in line:
+                step = line.split("STEP:")[1].strip()
+                stats["steps"].append({"name": step, "status": "INFO", "duration": None})
+
+            if "🤖 Agent" in line:
+                agent_name = line.split("[")[1].split("]")[0]
+                if "✅" in line:
+                    stats["agents"][agent_name]["success"] += 1
+                elif "❌" in line:
+                    stats["agents"][agent_name]["failed"] += 1
+
+            if "🌐 API" in line:
+                api_part = line.split("API [")[-1]
+                api_name = api_part.split("]")[0]
+                stats["api_calls"][api_name] += 1
+
+            if "ERROR" in line:
+                stats["errors"].append(line.strip())
+
+    return stats
+
+
+def print_summary(stats: Dict[str, object]) -> None:
+    metadata = stats.get("metadata") or {}
+    steps: Iterable[Dict[str, object]] = stats.get("steps", [])  # type: ignore[assignment]
+
     print("\n" + "=" * 60)
     print("📊 LOG ANALYSIS SUMMARY")
     print("=" * 60)
 
-    print(f"\n✅ Steps executed: {len(stats['steps'])}")
-    for step in stats["steps"]:
-        duration = stats["durations"].get(step, 0)
-        print(f"  - {step}: {duration:.2f}s")
+    if metadata:
+        session_id = metadata.get("session_id")
+        workflow_run_id = metadata.get("workflow_run_id")
+        status = metadata.get("status")
+        created_at = metadata.get("created_at")
+        updated_at = metadata.get("updated_at")
+        print("Session:", session_id or "(unknown)")
+        if workflow_run_id:
+            print("Workflow Run:", workflow_run_id)
+        if status:
+            print("Status:", status)
+        if created_at:
+            print("Started:", created_at)
+        if updated_at:
+            print("Updated:", updated_at)
 
+    print(f"\n✅ Steps recorded: {len(list(steps))}")
+    for step in steps:
+        status = step.get("status") or "INFO"
+        icon = "✅" if status == "SUCCESS" else ("❌" if status == "FAILED" else "•")
+        duration = step.get("duration")
+        duration_text = f" - {duration:.2f}s" if isinstance(duration, (int, float)) else ""
+        print(f"  {icon} {step.get('name')} {duration_text}")
+
+    agents = stats.get("agents", {})  # type: ignore[assignment]
     print("\n🤖 Agents:")
-    for agent, counts in stats["agents"].items():
-        total = counts["success"] + counts["failed"]
-        print(f"  - {agent}: {counts['success']}/{total} succeeded")
+    for agent, counts in agents.items():
+        success = counts.get("success", 0)
+        failed = counts.get("failed", 0)
+        total = success + failed
+        print(f"  - {agent}: {success}/{total} succeeded")
 
-    print(f"\n🌐 API Calls: {sum(stats['api_calls'].values())} total")
-    for api, count in stats["api_calls"].items():
+    api_calls = stats.get("api_calls", {})  # type: ignore[assignment]
+    total_calls = sum(api_calls.values())
+    print(f"\n🌐 API Calls: {total_calls} total")
+    for api, count in api_calls.items():
         print(f"  - {api}: {count} calls")
 
-    print(f"\n❌ Errors: {len(stats['errors'])}")
-    for error in stats["errors"][:5]:  # 最初の5件のみ
-        print(f"  - {error[:80]}...")
+    errors = stats.get("errors", [])  # type: ignore[assignment]
+    print(f"\n❌ Errors: {len(errors)}")
+    for error in errors[:5]:
+        print(f"  - {str(error)[:80]}...")
+
+
+def resolve_default_log() -> Tuple[Optional[Path], bool]:
+    log_dir = Path("logs")
+    structured = _discover_latest_structured(log_dir)
+    if structured:
+        return structured, True
+    text_log = _discover_latest_text(log_dir)
+    if text_log:
+        return text_log, False
+    return None, False
 
 
 if __name__ == "__main__":
-    import sys
+    target: Optional[Path] = None
+    prefer_structured = True
 
-    log_file = sys.argv[1] if len(sys.argv) > 1 else sorted(Path("logs").glob("workflow_*.log"))[-1]
-    stats = analyze_log(log_file)
-    print_summary(stats)
+    if len(sys.argv) > 1:
+        target_input = Path(sys.argv[1])
+        if target_input.is_dir():
+            metadata_file = target_input / "metadata.json"
+            if metadata_file.exists():
+                try:
+                    metadata = json.loads(metadata_file.read_text(encoding="utf-8"))
+                    structured_path = Path(metadata.get("paths", {}).get("structured", ""))
+                    if structured_path.exists():
+                        target = structured_path
+                    else:
+                        target = target_input / "workflow.log"
+                        prefer_structured = False
+                except json.JSONDecodeError:
+                    target = target_input / "workflow.log"
+                    prefer_structured = False
+            else:
+                target = target_input
+                prefer_structured = target_input.suffix == ".jsonl"
+        else:
+            target = target_input
+            prefer_structured = target.suffix == ".jsonl"
+    else:
+        target, prefer_structured = resolve_default_log()
+
+    if not target or not target.exists():
+        raise SystemExit("No log files found under logs/.")
+
+    if prefer_structured and target.suffix == ".jsonl":
+        summary = analyze_structured_log(target)
+    else:
+        summary = analyze_text_log(target)
+
+    print_summary(summary)

--- a/tests/unit/test_logging_config.py
+++ b/tests/unit/test_logging_config.py
@@ -1,0 +1,47 @@
+"""Tests for the logging configuration utilities."""
+
+import json
+import logging
+from pathlib import Path
+
+from app.logging_config import get_log_session, setup_logging
+
+
+def test_setup_logging_creates_structured_files(tmp_path):
+    log_dir = tmp_path / "logs"
+    session = setup_logging(log_level=logging.INFO, log_dir=str(log_dir), session_id="session_test")
+
+    try:
+        root = logging.getLogger()
+        root.info(
+            "Step completed",
+            extra={"event": "step_end", "step": "collect_news", "status": "SUCCESS", "duration": 1.2},
+        )
+        root.error("Something failed", extra={"step": "collect_news"})
+    finally:
+        logging.shutdown()
+
+    structured_entries = session.structured_log_path.read_text(encoding="utf-8").strip().splitlines()
+    assert structured_entries
+
+    first_entry = json.loads(structured_entries[0])
+    assert first_entry["session_id"] == "session_test"
+    assert first_entry["event"] == "step_end"
+    assert first_entry["step"] == "collect_news"
+
+    metadata = json.loads(session.metadata_path.read_text(encoding="utf-8"))
+    assert metadata["session_id"] == "session_test"
+    assert Path(metadata["paths"]["structured"]).name == "events.jsonl"
+
+
+def test_logging_session_status_updates(tmp_path):
+    log_dir = tmp_path / "logs"
+    session = setup_logging(log_level=logging.INFO, log_dir=str(log_dir), session_id="session_status")
+    session.mark_status("succeeded", execution_time_seconds=12.5)
+
+    metadata = json.loads(session.metadata_path.read_text(encoding="utf-8"))
+    assert metadata["status"] == "succeeded"
+    assert metadata["execution_time_seconds"] == 12.5
+
+    retrieved = get_log_session()
+    assert retrieved is session

--- a/tests/unit/test_tts.py
+++ b/tests/unit/test_tts.py
@@ -78,11 +78,10 @@ def test_split_by_speaker_only_newlines(tts_manager):
 
 
 def test_split_by_speaker_unrecognized_speaker(tts_manager):
-    """認識されない話者のテスト"""
+    """認識されない話者でもフォールバックとして処理されることをテスト"""
     text = "山田: こんにちは。"
-    expected = []
     result = tts_manager._split_by_speaker(text)
-    assert result == expected
+    assert result == [{"speaker": "山田", "content": "こんにちは。"}]
 
 
 def test_split_by_speaker_multiple_speakers_same_line(tts_manager):
@@ -99,8 +98,8 @@ def test_legacy_speaker_names_compatibility(tts_manager):
     result = tts_manager._split_by_speaker(text)
     # 旧話者名でも認識されること
     assert len(result) == 2
-    assert result[0]["speaker"] == "田中"
-    assert result[1]["speaker"] == "鈴木"
+    assert result[0]["speaker"] == "武宏"
+    assert result[1]["speaker"] == "つむぎ"
 
 
 def test_voice_config_contains_speaker_info(tts_manager):
@@ -132,3 +131,13 @@ def test_legacy_speaker_voice_config_mapping(tts_manager):
     # 鈴木 → つむぎ
     config_suzuki = tts_manager._get_voice_config("鈴木")
     assert config_suzuki["voicevox_speaker"] == 8
+
+
+def test_build_chunks_uses_fallback_voice_for_unknown_speaker(tts_manager):
+    """未知の話者でもフォールバック音声でチャンク化できることをテスト"""
+    chunks = tts_manager._build_chunks_from_dialogues(
+        [{"speaker": "山田", "line": "おはようございます。"}]
+    )
+
+    assert chunks
+    assert chunks[0]["speaker"] == tts_manager.speaker_registry.fallback_speaker


### PR DESCRIPTION
## Summary
- derive scripts from free-form LLM output with local dialogue validation and quality heuristics so generation succeeds even when JSON parsing fails
- let the TTS manager parse unknown speaker labels and route them through fallback voice definitions to keep synthesis running
- extend the unit suite to cover the relaxed fallbacks and surface the static quality report in metadata

## Testing
- ruff check .
- pytest tests/unit/test_structured_script_generator.py tests/unit/test_tts.py

------
https://chatgpt.com/codex/tasks/task_e_68e0dc9993c88325bbce3d7e8d6e5993