### PR TITLE
docs: add Japanese workflow documentation set

### DIFF
--- a/docs/マニュアル.md
+++ b/docs/マニュアル.md
@@ -1,0 +1,27 @@
+# マニュアル
+
+## 1. システムの目的と用語
+- このシステムは`YouTubeWorkflow`が11個の`WorkflowStep`を連携させ、ニュース収集からYouTube公開までの制作フローを自動化するために設計されている。【F:app/main.py†L31-L102】
+- `WorkflowStep`は各工程の振る舞いを定義する抽象クラスであり、`WorkflowContext`が工程間で共有するデータの保管庫、`StepResult`が成果報告書の役割を担う。【F:app/workflow/base.py†L11-L90】
+
+## 2. 初期セットアップ
+1. プロジェクトのルートで依存関係をインストールし、`.env`にAPIキーなどの秘密情報を配置する (リポジトリでは`.env`はGit管理外を想定)。
+2. `config.yaml`を環境に合わせて調整する。設定は`cfg`として読み込まれ、全ステップで参照されるため、API設定やメディアオプションをここで一元管理できる。【F:app/main.py†L25-L38】
+3. CrewAIを利用する場合はGoogle Sheetsのプロンプト管理が有効な状態にあることを確認する。プロンプトは自動で読み込まれ、使用履歴も記録される。【F:app/workflow/steps.py†L46-L65】
+
+## 3. 典型的な実行手順
+1. **フルワークフロー実行**: `uv run python3 -m app.main daily`で日次モードの自動制作を開始する。【F:README.md†L30-L33】
+2. **CrewAIフローの検証**: 台本生成のみ確認したい場合は`uv run python3 test_crewai_flow.py`を実行する。【F:README.md†L37-L38】
+3. **品質確認**: ワークフロー完了後、`QualityAssuranceStep`が生成するレポート(`qa_report_path`)を確認すると自動判定の詳細が把握できる。【F:app/workflow/steps.py†L557-L633】
+4. **成果物の場所**: 動画ステップは音声・字幕・台本・サムネイルをタイムスタンプ付きディレクトリに整理するため、アーカイブ先から一式を取得できる。【F:app/workflow/steps.py†L503-L548】
+
+## 4. トラブルシューティングのヒント
+- ニュース収集が失敗した場合はGoogle Sheets上のプロンプトや外部APIキーを見直す。ステップはニュースが0件だと即時失敗を返す設計である。【F:app/workflow/steps.py†L52-L69】
+- 台本生成でエラーが出た際はスクリプト構造検証ログ(最大5件の警告)と生成された`script_path`を確認する。CrewAIが失敗した場合でもレガシーフローへフォールバックできる。【F:app/workflow/steps.py†L112-L246】
+- 品質ゲートで差し戻された場合は`qa_retry_request`に記録された`start_step`と`reason`を参照し、指定ステップから再度実行する。【F:app/workflow/steps.py†L585-L624】【F:app/main.py†L134-L174】
+
+## 5. 保守運用のベストプラクティス
+- 変更を加えた際は`pytest tests/unit -v`でユニットテストを実行し、`uv run ruff check .`で静的解析を通す。【F:README.md†L40-L45】
+- 実行ログは`YouTubeWorkflow`が保持する`_log_session`を通じて記録されるため、障害解析時はログシステムと連携して経緯を追跡する。【F:app/main.py†L16-L199】
+- DriveやYouTubeへのアップロード結果は`StepResult`の`warning`フィールドにも格納される。公開に問題がないか最終確認する際に参照すると良い。【F:app/workflow/steps.py†L780-L865】
+

--- a/docs/技術報告書.md
+++ b/docs/技術報告書.md
@@ -1,0 +1,32 @@
+# 技術報告書
+
+## 1. システム概要
+- パイプラインはStrategyパターンで分割された`WorkflowStep`群と、それらをオーケストレートする`YouTubeWorkflow`から構成される。これにより個々の工程を独立してテスト・差し替えできるようにしている。【F:app/main.py†L59-L138】【F:app/workflow/base.py†L48-L90】
+- 各工程は`StepResult`で成果物と状態を返却し、`WorkflowContext`を介して次工程へ情報を引き継ぐ設計である。【F:app/workflow/base.py†L11-L45】
+
+## 2. 主要な技術的判断
+### 2.1 CrewAI統合と台本品質管理
+- 台本生成ステップはCrewAIフロー(`create_wow_script_crew`)による高品質生成とレガシー三段階チェックのフォールバックを持ち、どちらもスクリプト構造検証`ensure_dialogue_structure`を必須としている。【F:app/workflow/steps.py†L95-L246】
+- 検証結果は警告を最大5件ログ出力し、標準化済みテキストをファイルへ保存するため、後続のTTSや字幕処理が安定する。【F:app/workflow/steps.py†L126-L186】
+
+### 2.2 統一ビジュアル生成
+- `GenerateVisualDesignStep`はニュース内容と台本から抽出した感情トーンを基に`create_unified_design`を呼び出し、必要に応じてデフォルトテーマへフォールバックする。【F:app/workflow/steps.py†L270-L334】
+- 生成したデザインオブジェクトはサムネイルと動画生成ステップ双方で利用されるようディクショナリ化されており、視覚的統一感を担保する。【F:app/workflow/steps.py†L320-L334】
+
+### 2.3 メディア品質ゲートとリトライ機構
+- `QualityAssuranceStep`は`MediaQAPipeline`に台本・音声・字幕・動画を渡して解析し、ブロック対象が発生した場合は`qa_retry_request`に再開地点と理由を格納する。【F:app/workflow/steps.py†L557-L633】
+- ワークフロー側はこの指示を読み取り、`RETRY_CLEANUP_MAP`に基づいて不要な状態を削除した上で指定ステップから再実行する。これにより再試行が副作用なく行える。【F:app/main.py†L66-L174】
+
+## 3. データフローとファイル処理
+- 音声合成から字幕整合までの区間では、台本の再正規化→TTS→STT→SRT生成という直列フローを採用し、失敗時は早期に`_failure`を返して後続処理を止めるガードを備える。【F:app/workflow/steps.py†L338-L469】
+- 動画生成後は`FileArchivalManager`が音声・字幕・台本・サムネイルをタイムスタンプ付きディレクトリへ整理し、アーカイブ先パスにコンテキストを更新することで後続アップロードが安定する。【F:app/workflow/steps.py†L503-L548】
+
+## 4. 外部サービス連携
+- Google Sheetsからプロンプトを取得し、使用履歴を記録することでプロンプト管理のトレーサビリティを確保している。【F:app/workflow/steps.py†L46-L79】
+- Google Driveアップロードでは動画・サムネイル・字幕・メタデータをまとめて送信し、エラー内容を`warning`として保持するため、失敗してもログから原因を追跡できる。【F:app/workflow/steps.py†L761-L803】
+- YouTubeアップロード結果には動画IDとURLが含まれ、コンテキスト経由で`metadata_storage`へ統合されるため、公開済みコンテンツの分析が可能になる。【F:app/workflow/steps.py†L804-L865】【F:app/main.py†L181-L199】
+
+## 5. リスクと改善提案
+- ニュース収集・台本生成など外部API依存の工程は空データを返すと即座に失敗するため、今後は代替ソースのフェイルオーバー実装が望ましい。【F:app/workflow/steps.py†L52-L125】
+- メディア品質ゲートがブロックした際に許容リトライ回数を超えるとワークフロー全体が停止するため、QA項目ごとの重み付けや部分的な自動修正機能の追加が検討事項となる。【F:app/workflow/steps.py†L585-L624】【F:app/main.py†L127-L174】
+

--- a/docs/詳細設計仕様書.md
+++ b/docs/詳細設計仕様書.md
@@ -1,0 +1,43 @@
+# 詳細設計仕様書
+
+## 0. 状況整理
+- 本システムは`YouTubeWorkflow`クラスがStrategyパターンで定義された各`WorkflowStep`を順に実行し、ニュース取得から動画公開までの11工程を自動化するYouTube制作パイプラインである。【F:app/main.py†L31-L102】
+- 各ステップは`WorkflowStep`抽象基底クラスを継承し、共有コンテキスト`WorkflowContext`とステップ結果`StepResult`を介して疎結合に連携する構造を採用している。【F:app/workflow/base.py†L11-L90】
+
+## 1. 中央オーケストレーション
+| 要素 | 定義 (コード上の役割) | 直観的説明 |
+|------|-----------------------|------------|
+| `YouTubeWorkflow` | ステップ配列とリトライ戦略を保持し、コンテキストを生成して実行を制御するオーケストレータ。【F:app/main.py†L59-L174】 | プロジェクトマネージャーのように各担当者(ステップ)へ順番に仕事を依頼し、結果を整理しながら問題が起きたら再挑戦を判断する司令塔。 |
+| `RETRY_CLEANUP_MAP` | リトライ時にクリアすべきコンテキストキーをステップごとに定義するマッピング。【F:app/main.py†L66-L78】 | やり直す際に片付ける資料の一覧表。失敗した工程の中途半端な成果物を掃除して次の試行をクリーンにする。 |
+| `WorkflowContext` | 共有状態・生成物リストを管理するデータクラス。【F:app/workflow/base.py†L26-L45】 | 旅のしおりのように各工程で得た情報やファイルパスを保管し、次の担当者が参照できるようにする。 |
+| `StepResult` | 成功可否・生成データ・ファイル一覧をまとめるレスポンスオブジェクト。【F:app/workflow/base.py†L11-L23】 | 各担当者が提出する成果報告書。成功か失敗か、どんな資料を添付したかを明示する。 |
+
+## 2. ワークフローコンポーネント一覧
+| ステップ | 定義された振る舞い | 直観的説明 |
+|----------|---------------------|------------|
+| ニュース収集 (`CollectNewsStep`) | Google Sheetsからのプロンプト取得を含めニュース抽出を実行し、結果をコンテキストへ保存する。【F:app/workflow/steps.py†L36-L92】 | リサーチ担当がその日の注目経済ニュースを調べ、後続の制作チームに共有する。 |
+| 台本生成 (`GenerateScriptStep`) | CrewAIまたはレガシー生成を呼び出し、構造検証とファイル保存を行う。【F:app/workflow/steps.py†L95-L246】 | 台本作家がニュースを基に会話形式の脚本を作り、読みやすさを校正して全員がアクセスできる場所に置く。 |
+| 統一ビジュアル設計 (`GenerateVisualDesignStep`) | ニュースと台本からスタイルを算出し、デフォルトフォールバックも備える。【F:app/workflow/steps.py†L270-L335】 | アートディレクターが動画とサムネイルのテーマカラーや雰囲気を決め、制作物に一貫性を持たせる。 |
+| メタデータ生成 (`GenerateMetadataStep`) | タイトル・説明などを作成し、保存・フォールバック処理を実装する。【F:app/workflow/steps.py†L636-L701】 | 編集担当がYouTube用のタイトルや概要文を作り、問題があれば汎用テンプレートに切り替える。 |
+| サムネイル生成 (`GenerateThumbnailStep`) | ビジュアル設計スタイルを参照して画像を生成し、失敗時は警告を残す。【F:app/workflow/steps.py†L704-L759】 | デザイナーが決めたテーマを基にサムネイルを描き、うまくできなければ注意書きを添える。 |
+| 音声合成 (`SynthesizeAudioStep`) | 台本の再正規化とTTS生成を実行し、音声ファイルを記録する。【F:app/workflow/steps.py†L338-L390】 | ナレーターの代わりに合成音声を収録し、台本の不整合があれば修正してから読み上げる。 |
+| 音声書き起こし (`TranscribeAudioStep`) | WhisperベースのSTTで語彙列を抽出し、コンテキストに格納する。【F:app/workflow/steps.py†L393-L425】 | 収録した音声を聞き取り、どの単語がいつ話されたかを文字にして記録する。 |
+| 字幕整合 (`AlignSubtitlesStep`) | 台本とSTT結果を同期させ、SRTを出力する。【F:app/workflow/steps.py†L427-L469】 | 台本の行と実際の発話タイミングを合わせて、視聴者向け字幕ファイルを作る。 |
+| 動画生成 (`GenerateVideoStep`) | 音声・字幕・ニュース情報を統合し、成果物をアーカイブへ整理する。【F:app/workflow/steps.py†L471-L555】 | 映像編集者が音声と字幕を合成し、完成ファイルを所定のフォルダへまとめて保管する。 |
+| 品質保証 (`QualityAssuranceStep`) | `MediaQAPipeline`で品質チェックを行い、ブロック時はリトライ指示を記録する。【F:app/workflow/steps.py†L557-L633】 | 品質管理担当が動画を検査し、基準に達しない場合はどこからやり直すかを明示して差し戻す。 |
+| Driveアップロード (`UploadToDriveStep`) | 生成物一式をDriveへ送信し、警告も結果に含める。【F:app/workflow/steps.py†L761-L803】 | バックアップ担当が制作物を社内共有フォルダへアップロードし、問題があればメモを残す。 |
+| YouTubeアップロード (`UploadToYouTubeStep`) | 公開処理を行い、動画ID・URLを保存する。【F:app/workflow/steps.py†L804-L865】 | 配信担当がYouTubeに投稿し、出来上がったURLをチームへ共有する。 |
+| AIレビュー (`ReviewVideoStep`) | 生成動画を解析し、スクリーンショットや要約をコンテキストに格納する。【F:app/workflow/steps.py†L867-L942】 | 品質改善のためにAIレビューアーが動画を確認し、気付きとハイライト画像を添える。 |
+
+## 3. コンテキストとデータ管理
+- 各ステップは`context.set`でキーを登録し、後続ステップが`context.get`で取得することでバッテリーラインのような情報受け渡しを実現している。【F:app/workflow/base.py†L35-L45】【F:app/workflow/steps.py†L58-L65】【F:app/workflow/steps.py†L146-L158】
+- `YouTubeWorkflow`はステップが生成したファイルパスを`context.add_files`で記録し、成功時にまとめてメタデータ更新へ活用する。【F:app/main.py†L134-L199】【F:app/workflow/base.py†L43-L45】
+
+## 4. 生成物とファイル整理
+- 動画生成ステップは`FileArchivalManager`で音声・字幕・台本・サムネイルをタイムスタンプ付きディレクトリにまとめ、アーカイブされたパスをコンテキストへ再設定する。【F:app/workflow/steps.py†L503-L548】
+- Drive/YouTubeアップロードではそれぞれのAPIレスポンスを`StepResult`に含め、成功・警告・失敗を明示することで追跡可能な監査ログを構成する。【F:app/workflow/steps.py†L780-L865】
+
+## 5. 品質保証とリトライ戦略
+- 品質ゲートが有効な場合、`MediaQAPipeline`は台本・音声・字幕・動画を横断的に評価し、ブロッキング判定で`qa_retry_request`に再開ステップと理由を格納する。【F:app/workflow/steps.py†L557-L633】
+- ワークフロー本体はQA失敗時に`_resolve_step_index`で指定ステップに戻り、再試行前に不要な状態を`RETRY_CLEANUP_MAP`に従ってクリアすることで再実行を安定化させる。【F:app/main.py†L134-L174】
+


### PR DESCRIPTION
## Summary
- add a detailed design specification describing each workflow step and orchestration details in Japanese
- document technical decisions and risk analysis for the automated YouTube pipeline
- provide an operator-friendly manual covering setup, execution, and troubleshooting guidance

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1cb4c69288325bb47122326eafb5b