### PR TITLE
docs: add japanese workflow documentation set

### DIFF
--- a/docs/DETAILED_DESIGN_SPEC_JA.md
+++ b/docs/DETAILED_DESIGN_SPEC_JA.md
@@ -1,0 +1,83 @@
+# 詳細設計仕様書
+
+## 1. システム全体像
+- **目的**: 日次の経済ニュースからYouTube動画を自動生成し、台本・音声・映像・公開までを一貫管理する。ワークフローは `app/main.py` の `YouTubeWorkflow` クラスが戦略パターンで統制する。【F:app/main.py†L38-L102】
+- **制御フロー**: `YouTubeWorkflow.steps` に登録された `WorkflowStep` 実装を順番に実行し、`WorkflowContext` がステップ間の状態と生成ファイルを共有する。【F:app/main.py†L75-L102】【F:app/workflow/base.py†L12-L78】
+- **リトライ設計**: 品質検査での再試行指示を `RETRY_CLEANUP_MAP` が明示的に定義し、再実行時に不要なコンテキストを掃除する暗黙的挙動も補助する。【F:app/main.py†L46-L63】
+
+## 2. コア抽象コンポーネント
+### 2.1 WorkflowStep 基底クラス
+- **明示的定義**: `WorkflowStep` は `step_name` プロパティと `execute` メソッドを抽象化し、成功・失敗結果を `_success` と `_failure` ヘルパーで統一して返す。【F:app/workflow/base.py†L36-L77】
+- **暗黙的役割**: すべてのステップは副作用として `WorkflowContext` を更新する規約を共有し、テスト容易性を確保する（インターフェースに明文化されていないが `execute` 実装が一貫して `context.set` を呼び出す）。【F:app/workflow/steps.py†L33-L200】
+
+### 2.2 WorkflowContext / StepResult
+- **StepResult**: 成功可否、データ、生成ファイルを保持し、辞書ライクなアクセスをサポートする。【F:app/workflow/base.py†L12-L34】
+- **WorkflowContext**: 実行ID・モード・共有状態・生成ファイルを管理。`set`/`get`/`add_files` が明示定義されており、暗黙的に「ステップ間の通信バス」として働く。【F:app/workflow/base.py†L18-L35】
+
+## 3. ワークフローステップ詳細
+| ステップ | 明示的な定義 | 暗黙的な意図・副作用 |
+| --- | --- | --- |
+| CollectNewsStep | Perplexity/NewsAPIを使いニュースを収集し、プロンプトをシートとモードに応じて切り替える。【F:app/workflow/steps.py†L33-L117】 | Sheets連携が失敗した場合のフェイルセーフとしてローカルプロンプトにフォールバックする。ニュース結果を `context` に保存する規約を他ステップが暗黙依存。【F:app/workflow/steps.py†L87-L108】 |
+| GenerateScriptStep | CrewAI（構造化スクリプトジェネレータ）またはレガシー手段で台本を生成し、`ensure_dialogue_structure` で検証する。【F:app/workflow/steps.py†L120-L216】 | バリデーション警告をロギングし、`context` に品質メトリクスと構造化データを格納することで後続ステップ（字幕整合・QA）が暗黙的に活用。 |
+| GenerateVisualDesignStep | 統一デザインを算出し、サムネ・動画に共通テーマを提供。【F:app/workflow/steps.py†L305-L373】 | `UnifiedVisualDesign.create_from_news` がニュース感情に基づいてテーマを選択し、背景テーマ管理のA/Bテスト結果を暗黙的に活用する。【F:app/services/visual_design.py†L17-L104】 |
+| GenerateMetadataStep | Geminiを用いてタイトル・説明文等を生成し、SEO要件を満たすようバリデーションする。【F:app/workflow/steps.py†L375-L446】 | メタデータは `context` に保存され、Drive/YouTube アップロードで暗黙的に参照される。 |
+| GenerateThumbnailStep | 視覚デザインとスクリプトからサムネイルを生成し、ファイルを追跡する。【F:app/workflow/steps.py†L448-L538】 | サムネイル生成サービスはデザイン設定の暗黙インターフェースを利用し、`context` に書き込んだファイルパスが後続の動画生成で利用される。 |
+| SynthesizeAudioStep | TTSで台本を音声化し、生成パスを返す。【F:app/workflow/steps.py†L540-L638】 | スピーカー設定は `settings.speakers` の暗黙的制約に従い、音声品質QAの入力となる。 |
+| TranscribeAudioStep | 音声からSTT結果を作成し、単語タイムスタンプを提供。【F:app/workflow/steps.py†L640-L714】 | 字幕整合が `stt_words` を必要とするため、`context` 保持が暗黙的契約。 |
+| AlignSubtitlesStep | 台本とSTTを付き合わせて字幕を整列し、SRTを書き出す。【F:app/workflow/steps.py†L716-L817】【F:app/align_subtitles.py†L1-L120】 | 日本語品質チェックは存在すれば自動適用される（依存モジュールの存在チェックによる暗黙機能）。【F:app/align_subtitles.py†L13-L24】 |
+| GenerateVideoStep | 音声・字幕・背景デザインを合成して動画を作成。ストック映像の使用可否を判断し、FFmpeg設定を適用。【F:app/workflow/steps.py†L819-L935】【F:app/video.py†L1-L129】 | テーマA/Bテストやストック映像切替は設定値から暗黙的に決定され、ファイルアーカイブ管理が副作用として働く。【F:app/video.py†L30-L124】 |
+| QualityAssuranceStep | MediaQAPipelineで音声・字幕・動画の品質検査を実施し、ブロック条件を判定。【F:app/workflow/steps.py†L937-L1015】【F:app/services/media/qa_pipeline.py†L1-L142】 | QAレポートの永続化は例外非同期にも失敗しないよう警告に留める暗黙設計。再試行要求は `context` に `qa_retry_request` を設定する。 |
+| UploadToDriveStep | 生成物をDriveへアップロードし、共有リンクを返す。【F:app/workflow/steps.py†L1017-L1077】 | `FileArchivalManager` が暗黙的にアーカイブを生成し、失敗時はローカル保持のみで進行する。 |
+| UploadToYouTubeStep | YouTube Data APIで動画を公開し、動画IDとURLを記録。【F:app/workflow/steps.py†L1079-L1167】 | メタデータやサムネイルが `context` から暗黙参照される設計。 |
+| ReviewVideoStep | 生成動画をAIレビューにかけ、フィードバックを生成して保存。【F:app/workflow/steps.py†L1169-L1254】 | フィードバックは次回改善のための記録として暗黙に扱われる。 |
+
+## 4. サービス層コンポーネント
+### 4.1 ニュース収集 (`NewsCollector`)
+- **定義**: Perplexity APIキーのローテーション、NewsAPIフォールバック、ダミーニュース生成を管理。【F:app/search_news.py†L1-L120】
+- **直観的説明**: まず複数のPerplexityキーを順番に試し、失敗すれば一般ニュースAPI、それでも駄目ならテスト用ニュースを返す「三段構えのニュース調達係」。
+
+### 4.2 スクリプト生成 (`StructuredScriptGenerator`)
+- **定義**: Geminiを呼び出しJSONスキーマで台本を取得し、`ensure_dialogue_structure` で検証する。【F:app/services/script/generator.py†L1-L135】
+- **直観的説明**: ニュース要約をもとに「会話台本のテンプレ」に沿ってLLMにお願いし、万一JSON化に失敗してもテキストから復元する保険を持つ台本職人。
+
+### 4.3 スクリプト検証 (`ensure_dialogue_structure`)
+- **定義**: 台本を行単位で整形し、話者・対話比率・敬称などを確認する。【F:app/services/script/validator.py†L1-L120】【F:app/services/script/validator.py†L171-L255】
+- **直観的説明**: 「話者ラベルが付いているか」「会話が十分に交互しているか」を機械的に点検する校正係。
+
+### 4.4 字幕整合 (`SubtitleAligner`)
+- **定義**: 台本の文とSTT結果を類似度でマッチングし、最大表示時間・二行表示などのガイドラインを適用してSRTを生成する。【F:app/align_subtitles.py†L1-L120】
+- **直観的説明**: 音声で発話された単語のタイミングを頼りに台本の文を当てはめ、読める長さに自動調整する字幕職人。
+
+### 4.5 動画生成 (`VideoGenerator`)
+- **定義**: FFmpegで音声・字幕・背景を合成し、必要ならストック映像へ切り替える。背景テーマはA/Bテストで選択する。【F:app/video.py†L1-L124】
+- **直観的説明**: まずストック映像の豪華版を試し、駄目なら自前の動く背景を用意して字幕を重ねる映像編集者。テーマの選択やアーカイブ保存も同時にこなす。
+
+### 4.6 メディアQA (`MediaQAPipeline`)
+- **定義**: 音声レベル、字幕カバレッジ、動画ビットレートなどを検査し、結果を `QualityGateReport` にまとめる。【F:app/services/media/qa_pipeline.py†L1-L142】【F:app/services/media/qa_pipeline.py†L144-L246】
+- **直観的説明**: 生成物を受け取り「音が割れていないか」「字幕が追いついているか」「動画が高解像度か」をチェックする検品担当。基準を満たさなければ再実行を要求する。
+
+### 4.7 ビジュアルデザイン (`UnifiedVisualDesign`)
+- **定義**: ニュースの感情解析からテーマ色と背景テーマを選び、サムネイル・動画双方に渡す。【F:app/services/visual_design.py†L1-L104】
+- **直観的説明**: ニュースがポジティブなら緑、警告なら赤といった感情に合わせてブランド一貫性を保つアートディレクター。
+
+## 5. 設定と外部依存
+- **設定読み込み**: `app/config/settings.py` が `config.yaml` と `.env` を統合し、Pydanticモデルで構造化する。話者・動画・QA設定などが明示的フィールドとして定義され、バリデーションで環境変数から音声IDを補完する。【F:app/config/settings.py†L1-L120】
+- **暗黙的依存**: Geminiモデル名や話者数など、設定が成立していることを `StructuredScriptGenerator` が前提としており、2人以上の話者がいなければ初期化時にエラーを投げる。【F:app/services/script/generator.py†L55-L88】
+- **外部サービス**: Perplexity/Gemini/YouTube/Google Drive/VOICEVOX/FFmpeg/Pydub 等を利用。APIキーは `initialize_api_infrastructure` でローテーション管理を初期化する。【F:app/main.py†L24-L37】【F:app/search_news.py†L13-L78】
+
+## 6. エラーハンドリング戦略
+- **ニュース取得失敗**: 例外を捕捉しつつ段階的フォールバック。最終的にダミーデータを返し、ワークフロー継続を優先。【F:app/search_news.py†L39-L118】
+- **スクリプト生成失敗**: JSON解析失敗時はテキスト整形へフォールバックし、品質ゲートが有効なら再試行する。【F:app/services/script/generator.py†L89-L148】
+- **QA失敗**: `MediaQAPipeline.should_block` が `config.media_quality.gating` を参照し、再試行許可モード以外では即停止する。【F:app/services/media/qa_pipeline.py†L40-L83】
+- **アップロード失敗**: 例外はログ出力しつつ `StepResult` で失敗を返す。`YouTubeWorkflow` 側でエラーを拾い、Discord通知やクリーンアップを行う暗黙設計（`execute_full_workflow` 内でハンドリング）。【F:app/main.py†L104-L205】
+
+## 7. データ永続化とアーカイブ
+- **ファイルトラッキング**: 各ステップは生成ファイルパスを `StepResult.files_generated` に積み、`WorkflowContext.add_files` が集約して最終的な後処理を容易にする。【F:app/workflow/base.py†L12-L35】【F:app/main.py†L120-L149】
+- **アーカイブ**: 動画生成時に `FileArchivalManager` が原稿・音声・字幕をコピーし、再利用に備える暗黙機能。【F:app/video.py†L30-L60】
+
+## 8. 品質・改善ループ
+- **WOW/日本語純度閾値**: `config.yaml` の `quality_thresholds` がスクリプト品質指標の目標を定義し、CrewAIメタデータ経由で検査する暗黙仕様。【F:config.yaml†L69-L122】
+- **動画レビュー**: `ReviewVideoStep` が AI モデルにスクリーンショットを解析させ、フィードバックを `context` に保存することで次回改修の材料を残す。【F:app/workflow/steps.py†L1169-L1254】
+
+## 9. まとめ
+本システムは戦略パターンで分解されたワークフローを、設定駆動・品質ゲート付きで統合する。各ステップは明示的なインターフェース (`WorkflowStep`) に従う一方、`WorkflowContext` に値を格納する暗黙契約で連携し、エラーフォールバックと再試行により信頼性を確保する。

--- a/docs/TECHNICAL_REPORT_JA.md
+++ b/docs/TECHNICAL_REPORT_JA.md
@@ -1,0 +1,43 @@
+# 技術報告書
+
+## 1. 実行目的とスコープ
+- 本報告書は、金融系YouTube自動生成システムの技術的成立性と改善余地を説明する。対象は `YouTubeWorkflow` に含まれるニュース収集から動画公開までの全ステップ。【F:app/main.py†L75-L102】
+- 実装はPython 3.10準拠で、Pydantic設定、CrewAI/Gemini API、FFmpeg、VOICEVOXなど複数の外部サービスを統合している。【F:app/config/settings.py†L1-L120】【F:app/video.py†L1-L60】
+
+## 2. パイプライン処理の技術詳細
+### 2.1 ニュース→台本フェーズ
+1. **ニュース収集**: `NewsCollector.collect_news` がPerplexity APIキーのローテーションを行い、JSON形式のニュース要約を取得。失敗時はNewsAPIおよびダミーデータへ段階的にフォールバックする。【F:app/search_news.py†L33-L118】
+2. **台本生成**: `StructuredScriptGenerator.generate` がニュース要約をプロンプトに整形し、GeminiへJSONのみの回答を要求。JSONが解析できない場合はテキスト再構成で保険を掛ける。【F:app/services/script/generator.py†L62-L148】
+3. **台本検証**: `ensure_dialogue_structure` が話者名の整形・敬称の補正・対話比率の検査を実施。Pydanticモデル `Script` が最低2名の話者を保証する。【F:app/services/script/validator.py†L1-L120】【F:app/services/script/validator.py†L130-L170】
+
+### 2.2 メディア生成フェーズ
+1. **音声合成**: `SynthesizeAudioStep` が設定内の話者ごとにTTSを実行し、音声ファイルを保存。生成されたパスは `WorkflowContext` へ渡される。【F:app/workflow/steps.py†L540-L638】
+2. **STT・字幕整合**: `TranscribeAudioStep` が長尺音声向けのSTT（`transcribe_long_audio`）を呼び出し、単語タイムスタンプを生成。その後 `SubtitleAligner.align_script_with_stt` が類似度マッチングで字幕を分割する。【F:app/workflow/steps.py†L640-L817】【F:app/align_subtitles.py†L1-L120】
+3. **動画生成**: `VideoGenerator.generate_video` がFFmpegフィルタを構築し、ストック映像が利用可能なら優先的に合成する。背景テーマのA/Bテストとアーカイブ保存も同時に行う。【F:app/video.py†L1-L124】
+4. **ビジュアルデザイン統一**: `UnifiedVisualDesign.create_from_news` がニュース感情を分析し、テーマ色とフォントサイズを決定。サムネイルと動画で共有することでブランド一貫性を担保する。【F:app/services/visual_design.py†L17-L104】
+
+### 2.3 品質・公開フェーズ
+1. **メディアQA**: `MediaQAPipeline.run` が音声のRMS/ピーク、字幕行数比、動画解像度を検査し、`QualityGateReport` に結果を記録する。しきい値は `config.media_quality` によって調整可能。【F:app/services/media/qa_pipeline.py†L1-L142】【F:config.yaml†L45-L94】
+2. **再試行判定**: QAの失敗が発生すると `QualityAssuranceStep` が `qa_retry_request` を `WorkflowContext` に書き込み、`YouTubeWorkflow` が指定ステップからの再開を準備する。【F:app/workflow/steps.py†L937-L1015】【F:app/main.py†L104-L205】
+3. **アップロード**: `UploadToDriveStep` と `UploadToYouTubeStep` がそれぞれDriveとYouTube APIへファイルを送信。成功時は共有URL・動画IDを `WorkflowContext` に格納する。【F:app/workflow/steps.py†L1017-L1167】
+4. **AIレビュー**: `ReviewVideoStep` が生成動画から一定間隔でスクリーンショットを抽出し、Geminiモデルによる内容評価を保存する。【F:app/workflow/steps.py†L1169-L1254】
+
+## 3. 主要技術要素の分析
+- **APIキー管理**: `initialize_api_infrastructure` および `get_rotation_manager` がAPIキーのローテーションを統括。これによりPerplexity/Geminiのレート制限に耐性がある。【F:app/main.py†L24-L37】【F:app/search_news.py†L13-L78】
+- **設定駆動性**: `settings` オブジェクトが `.env` と `config.yaml` を統合し、話者の音声IDは環境変数から自動取得されるバリデータで補完される。【F:app/config/settings.py†L1-L49】
+- **品質ゲート**: `MediaQAPipeline.should_block` がモード別のスキップや失敗時のブロック判定を行い、動画品質の最低ラインを保証する。【F:app/services/media/qa_pipeline.py†L40-L83】
+- **フォールトトレランス**: 各ステップが例外を捕捉してフォールバックを返し、システム全体が止まることを避ける設計となっている。例: ニュース収集のダミーデータ、スクリプト再生成、字幕推定など。【F:app/search_news.py†L39-L118】【F:app/services/script/generator.py†L110-L148】【F:app/align_subtitles.py†L73-L120】
+
+## 4. 技術リスクと改善提案
+1. **外部API依存**: レート制限はローテーションで緩和しているが、全キーが失効した場合の通知経路が未整備。Discord通知や監視メトリクスの追加が望ましい。【F:app/search_news.py†L39-L118】
+2. **字幕品質**: 現状は類似度閾値で整合しているため、話者推定の誤差が残る可能性がある。Speaker diarizationの導入で改善可能。【F:app/align_subtitles.py†L25-L120】
+3. **QAカバレッジ**: 音声の主観的品質（イントネーション等）は検知できないため、人力レビューや追加モデルの導入を検討する。
+4. **設定整合性**: 設定変更時の整合チェックが初期化フェーズに分散している。`app.verify` の拡張で自動検証を強化すると運用負担が減る可能性がある。
+
+## 5. 運用インパクト
+- **ログと監視**: `setup_logging` と `get_log_session` が実行ごとにログセッションIDを付与し、障害追跡を容易にする。【F:app/main.py†L10-L34】
+- **ファイルアーカイブ**: `FileArchivalManager` が生成物を保管し、再編集や再公開を支援する。失敗時でもワークフロー継続が可能なため、運用コストを抑制できる。【F:app/video.py†L30-L60】
+- **品質指標**: `quality_thresholds` に基づくWOWスコア等は、CrewAIから取得したメタデータを用いてモニタリングできる設計であり、日々の改善サイクルを回しやすい。【F:config.yaml†L69-L122】【F:app/workflow/steps.py†L120-L216】
+
+## 6. まとめ
+本システムは、設定駆動・フォールバック重視のアーキテクチャで自動動画生成を実現している。API依存への冗長化、字幕品質向上、QA拡張が今後の重点改善項目である。ワークフロー分割と品質ゲートにより、初見でも各ステップの役割を追跡しやすい実装となっている。

--- a/docs/USER_MANUAL_JA.md
+++ b/docs/USER_MANUAL_JA.md
@@ -1,0 +1,58 @@
+# 運用マニュアル
+
+## 1. システム概要
+- 本マニュアルは金融系YouTube自動生成システムの運用者向けガイドである。ワークフローは `app/main.py` の `YouTubeWorkflow` が管理し、ステップ単位で失敗・再試行が制御される。【F:app/main.py†L38-L149】
+
+## 2. 前提準備
+1. **Python環境**: Python 3.10 以上。リポジトリ同梱の `pyproject.toml` に従って依存をインストールする（`uv pip sync` 等）。
+2. **設定ファイル**:
+   - `config.yaml` を編集し、話者、品質基準、動画設定を自社の要件へ合わせる。【F:config.yaml†L1-L122】
+   - `.env` にAPIキー（Perplexity/Gemini/YouTube/Google Drive/TTS等）を記述。`app/config/settings.py` が自動で読み込む。【F:app/config/settings.py†L1-L49】
+3. **外部コマンド**: FFmpegとVOICEVOXエンジンをインストールし、PATHに通す。FFmpegパスは `config.yaml` の `stock_footage.ffmpeg_path` で上書き可能。【F:config.yaml†L33-L53】【F:app/video.py†L1-L60】
+
+## 3. 典型的な運用フロー
+1. **検証**: 長時間実行前に `uv run python -m app.verify` を実行し、設定とAPIキーが有効かチェックする。
+2. **日次実行**: 以下のコマンドで日次動画を生成する。
+   ```bash
+   uv run python3 -m app.main daily
+   ```
+   - モードは `daily`（通常）、`special`（特集）、`test`（検証）の3種。`YouTubeWorkflow.execute_full_workflow` の `mode` 引数で切り替わり、ニュースプロンプトやQAリトライ条件が変化する。【F:app/main.py†L104-L205】【F:app/workflow/steps.py†L39-L117】
+3. **途中停止時のリカバリ**:
+   - ログを確認し、失敗したステップ名と `qa_retry_request` の内容から再実行位置を把握する。【F:app/main.py†L104-L205】【F:app/workflow/steps.py†L937-L1015】
+   - 必要なら `data/qa_reports` の品質レポートで具体的な失敗理由を確認する。【F:config.yaml†L45-L94】
+4. **成果物の確認**:
+   - 台本・音声・字幕・動画は `output/` やアーカイブディレクトリに保存され、`WorkflowContext.generated_files` でも一覧化される。【F:app/workflow/base.py†L18-L35】【F:app/main.py†L120-L149】
+   - `ReviewVideoStep` が生成したフィードバックは `output/video_reviews` に格納される。【F:config.yaml†L55-L66】【F:app/workflow/steps.py†L1169-L1254】
+
+## 4. 個別ステップの操作ポイント
+- **ニュース収集**: Google Sheetsのプロンプトが利用できない場合、自動的にローカルデフォルトに切り替わるため手動対応は不要。ただしAPIキー不足時は`.env`更新後に再実行する。【F:app/workflow/steps.py†L39-L117】【F:app/search_news.py†L13-L78】
+- **台本編集**: 生成台本は `context` に保存されたパス（例: `script_YYYYmmdd.txt`）を直接編集し、再実行時に上書きされないようコピーを作成する。【F:app/workflow/steps.py†L152-L200】
+- **サムネイル調整**: 統一デザインの色味を変えたい場合は `app/background_theme.py` や `config.yaml` のテーマ設定を編集する。変更後は `GenerateThumbnailStep` が新デザインで再生成する。【F:app/workflow/steps.py†L305-L538】【F:app/services/visual_design.py†L17-L104】
+- **音声/TTS**: VOICEVOX話者IDを変更する場合、`config.yaml` の `speakers` セクションを更新し、該当環境変数（例: `TTS_VOICE_TAKEHIRO`）を設定する。【F:config.yaml†L9-L32】【F:app/config/settings.py†L15-L49】
+- **字幕確認**: `data/qa_reports` の字幕セクションに `line_ratio` や `timing_gap_seconds` が記録される。閾値を緩めたい場合は `config.yaml` の `media_quality.subtitles` を調整する。【F:app/services/media/qa_pipeline.py†L144-L246】【F:config.yaml†L45-L94】
+- **動画生成**: 背景テーマを固定したい場合は `GenerateVideoStep` 実行前に `context` の `visual_design` を目的のテーマに設定してから再実行する。`use_stock_footage` フラグは `config.yaml` の `stock_footage.enabled` で制御する。【F:app/workflow/steps.py†L819-L935】【F:config.yaml†L33-L41】
+- **品質ゲート**: QAでブロックされた場合、`config.yaml` の `media_quality.gating.retry_attempts` を増やすと自動再試行回数が増える。運用中に一時的にスキップしたい場合は `mode` を `test` にするとゲートが緩和される。【F:config.yaml†L45-L65】【F:app/services/media/qa_pipeline.py†L40-L83】
+- **公開情報編集**: YouTube投稿後にタイトルや説明文を手動調整する場合、`GenerateMetadataStep` が出力したJSON（`metadata.json`など）を参照し、YouTube Studioで微調整する。【F:app/workflow/steps.py†L375-L446】
+
+## 5. トラブルシューティング
+| 症状 | チェックポイント | 対処 |
+| --- | --- | --- |
+| ニュースが取得できない | ログに「All news collection methods failed」| `.env` の Perplexity/NewsAPI キーを更新し再実行。【F:app/search_news.py†L39-L118】 |
+| 台本が空になる | QAログに `Generated script too short` | ニュース件数を確認し、CrewAI設定 (`config.yaml.crew`) を有効化する。【F:app/workflow/steps.py†L120-L216】【F:config.yaml†L95-L122】 |
+| 字幕がずれる | QAレポートの `subtitle_alignment` セクション | `TranscribeAudioStep` のSTT結果を再生成し、音量レベルが低すぎないか確認する。【F:app/workflow/steps.py†L640-L817】【F:app/services/media/qa_pipeline.py†L144-L246】 |
+| 動画生成に失敗 | ログにFFmpegエラー | `stock_footage.enabled` を一時的にfalseにして再実行。背景画像のパスを確認。【F:app/video.py†L70-L124】【F:config.yaml†L33-L41】 |
+| QAでブロック | レポートの `blocking_failures` | `media_quality` 閾値を調整、または該当ステップを手動で修正して再実行。【F:app/services/media/qa_pipeline.py†L40-L83】 |
+
+## 6. ベストプラクティス
+- 日次実行前に `git pull` で最新コードと設定を取得し、変更点を確認する。
+- APIキーのローテーション設定を四半期ごとに見直し、`get_rotation_manager` に登録されているキー数が十分かを確認する。【F:app/search_news.py†L13-L78】
+- QAレポートとAIレビューをNotionやSlackに転送し、継続的改善のタスクリストを作成する。
+- 新しい話者を追加するときは、`StructuredScriptGenerator` が最低2話者を要求する点に注意して、台本テンプレの整合性を保つ。【F:app/services/script/generator.py†L55-L88】
+
+## 7. 参考コマンド
+- CrewAIフロー単体テスト: `uv run python3 test_crewai_flow.py`
+- メディアQAのみ再実行: `uv run python -m app.workflow.qa_runner --run-id <ID>`（拡張を想定した運用コマンド）
+- ログファイルの追跡: `tail -f logs/<run_id>.log`
+
+## 8. まとめ
+運用者は設定ファイルと`.env`の整合を維持し、失敗したステップに応じて再実行範囲を調整することで効率的な自動動画生成が実現できる。ログ、QAレポート、AIレビューを定期的に見直すことで品質を継続的に向上できる。


### PR DESCRIPTION
## Summary
- add a Japanese detailed design specification explaining the workflow steps and supporting services
- document the current technical implementation, risks, and improvement ideas in a Japanese technical report
- provide a Japanese operator manual covering setup, execution, and troubleshooting guidance

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e1cb4c69288325bb47122326eafb5b