### PR TITLE
refactor: auto augment structured script speakers

### DIFF
--- a/docs/DETAILED_DESIGN_SPEC_JA.md
+++ b/docs/DETAILED_DESIGN_SPEC_JA.md
@@ -62,7 +62,7 @@
 
 ## 5. 設定と外部依存
 - **設定読み込み**: `app/config/settings.py` が `config.yaml` と `.env` を統合し、Pydanticモデルで構造化する。話者・動画・QA設定などが明示的フィールドとして定義され、バリデーションで環境変数から音声IDを補完する。【F:app/config/settings.py†L1-L120】
-- **暗黙的依存**: Geminiモデル名や話者数など、設定が成立していることを `StructuredScriptGenerator` が前提としており、2人以上の話者がいなければ初期化時にエラーを投げる。【F:app/services/script/generator.py†L55-L88】
+- **暗黙的依存**: Geminiモデル名や話者数など、設定が成立していることを `StructuredScriptGenerator` が前提とする点は変わらないが、話者が不足しても `SpeakerRoster` がプレースホルダーを補完しつつ警告を出すため、初期化エラーではなく品質警告として扱われる。【F:app/services/script/generator.py†L55-L151】
 - **外部サービス**: Perplexity/Gemini/YouTube/Google Drive/VOICEVOX/FFmpeg/Pydub 等を利用。APIキーは `initialize_api_infrastructure` でローテーション管理を初期化する。【F:app/main.py†L24-L37】【F:app/search_news.py†L13-L78】
 
 ## 6. エラーハンドリング戦略

--- a/docs/USER_MANUAL_JA.md
+++ b/docs/USER_MANUAL_JA.md
@@ -47,7 +47,7 @@
 - 日次実行前に `git pull` で最新コードと設定を取得し、変更点を確認する。
 - APIキーのローテーション設定を四半期ごとに見直し、`get_rotation_manager` に登録されているキー数が十分かを確認する。【F:app/search_news.py†L13-L78】
 - QAレポートとAIレビューをNotionやSlackに転送し、継続的改善のタスクリストを作成する。
-- 新しい話者を追加するときは、`StructuredScriptGenerator` が最低2話者を要求する点に注意して、台本テンプレの整合性を保つ。【F:app/services/script/generator.py†L55-L88】
+- 新しい話者を追加するときは、`StructuredScriptGenerator` が不足分を自動補完して警告を出す仕組みになった。1人しか設定しない場合でもプレースホルダー話者が補われるため、会話テンプレの整合性を維持しつつ手動設定の抜け漏れを検知できる。【F:app/services/script/generator.py†L55-L132】
 
 ## 7. 参考コマンド
 - CrewAIフロー単体テスト: `uv run python3 test_crewai_flow.py`


### PR DESCRIPTION
## Summary
- introduce a SpeakerRoster helper that pads missing speaker entries and emits warnings instead of failing
- allow StructuredScriptGenerator to accept custom speaker lists while propagating roster warnings into quality reports
- document the new behavior and cover single- or zero-speaker scenarios with unit tests

## Testing
- pytest tests/unit/test_structured_script_generator.py

------
https://chatgpt.com/codex/tasks/task_e_68e1d156dd948325af0d2d8bf992101d