### PR TITLE
fix: validate ffmpeg tooling before video generation

### DIFF
--- a/app/services/media/__init__.py
+++ b/app/services/media/__init__.py
@@ -1,6 +1,7 @@
 """Media services for video generation and enhancement."""
 
 from .broll_generator import BRollGenerator
+from .ffmpeg_support import ensure_ffmpeg_tooling, FFmpegConfigurationError
 from .qa_pipeline import MediaQAError, MediaQAPipeline
 from .stock_footage_manager import StockFootageManager
 from .visual_matcher import VisualMatcher
@@ -11,4 +12,6 @@ __all__ = [
     "BRollGenerator",
     "MediaQAPipeline",
     "MediaQAError",
+    "ensure_ffmpeg_tooling",
+    "FFmpegConfigurationError",
 ]

--- a/app/services/media/broll_generator.py
+++ b/app/services/media/broll_generator.py
@@ -11,6 +11,8 @@ import tempfile
 from pathlib import Path
 from typing import List, Optional
 
+from app.services.media.ffmpeg_support import ensure_ffmpeg_tooling
+
 logger = logging.getLogger(__name__)
 
 
@@ -23,21 +25,7 @@ class BRollGenerator:
         Args:
             ffmpeg_path: Path to ffmpeg executable
         """
-        self.ffmpeg_path = ffmpeg_path
-        self._verify_ffmpeg()
-
-    def _verify_ffmpeg(self):
-        """Verify ffmpeg is available."""
-        try:
-            subprocess.run(
-                [self.ffmpeg_path, "-version"],
-                capture_output=True,
-                check=True,
-                timeout=5,
-            )
-            logger.info("FFmpeg verified successfully")
-        except Exception as e:
-            logger.warning(f"FFmpeg verification failed: {e}")
+        self.ffmpeg_path = ensure_ffmpeg_tooling(ffmpeg_path)
 
     def create_broll_sequence(
         self,

--- a/app/services/media/ffmpeg_support.py
+++ b/app/services/media/ffmpeg_support.py
@@ -1,0 +1,91 @@
+"""FFmpeg configuration helpers shared across media services."""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import subprocess
+from functools import lru_cache
+from pathlib import Path
+from typing import Optional
+
+from pydub import AudioSegment
+
+logger = logging.getLogger(__name__)
+
+
+class FFmpegConfigurationError(RuntimeError):
+    """Raised when FFmpeg validation commands fail."""
+
+
+def _resolve_ffmpeg_path(requested_path: Optional[str]) -> str:
+    """Resolve the FFmpeg binary path from configuration or defaults."""
+
+    candidate = (requested_path or "ffmpeg").strip() or "ffmpeg"
+
+    resolved = shutil.which(candidate)
+    if resolved:
+        return resolved
+
+    candidate_path = Path(candidate).expanduser()
+    if candidate_path.exists():
+        return str(candidate_path)
+
+    raise FileNotFoundError(f"FFmpeg binary not found for '{candidate}'")
+
+
+def _run_ffmpeg_command(cmd: list[str]) -> None:
+    """Execute a lightweight FFmpeg command to validate availability."""
+
+    try:
+        subprocess.run(cmd, capture_output=True, check=True, timeout=5)
+    except subprocess.TimeoutExpired as exc:
+        joined = " ".join(cmd)
+        raise FFmpegConfigurationError(f"Timed out while executing '{joined}'") from exc
+    except subprocess.CalledProcessError as exc:
+        stderr = exc.stderr.decode(errors="ignore") if exc.stderr else ""
+        joined = " ".join(cmd)
+        raise FFmpegConfigurationError(f"FFmpeg command failed ({joined}): {stderr.strip()}") from exc
+    except FileNotFoundError as exc:
+        raise FileNotFoundError(f"FFmpeg executable missing: {cmd[0]}") from exc
+
+
+def _verify_ffmpeg_binary(binary: str) -> None:
+    """Run a pair of diagnostic FFmpeg commands to ensure support."""
+
+    diagnostics = (
+        [binary, "-version"],
+        [binary, "-hide_banner", "-filters"],
+    )
+    for cmd in diagnostics:
+        _run_ffmpeg_command(cmd)
+
+
+def _configure_pydub(binary: str) -> None:
+    """Point pydub's AudioSegment helpers at the validated FFmpeg binary."""
+
+    AudioSegment.converter = binary
+    AudioSegment.ffmpeg = binary
+
+    ffprobe = shutil.which("ffprobe")
+    if not ffprobe:
+        sibling = Path(binary).with_name("ffprobe")
+        if sibling.exists():
+            ffprobe = str(sibling)
+
+    if ffprobe:
+        AudioSegment.ffprobe = ffprobe
+    else:
+        logger.debug("ffprobe binary not found alongside %s", binary)
+
+
+@lru_cache(maxsize=None)
+def ensure_ffmpeg_tooling(requested_path: Optional[str] = None) -> str:
+    """Validate FFmpeg availability and align AudioSegment with the binary."""
+
+    resolved = _resolve_ffmpeg_path(requested_path)
+    _verify_ffmpeg_binary(resolved)
+    _configure_pydub(resolved)
+    logger.debug("FFmpeg configured for AudioSegment at %s", resolved)
+    return resolved
+

--- a/app/video.py
+++ b/app/video.py
@@ -19,6 +19,7 @@ from app.config.paths import ProjectPaths
 from app.config.settings import settings
 from app.services.file_archival import FileArchivalManager
 from app.utils import FileUtils
+from app.services.media.ffmpeg_support import ensure_ffmpeg_tooling
 
 from .background_theme import BackgroundTheme, get_theme_manager
 
@@ -44,6 +45,7 @@ class VideoGenerator:
 
         # Initialize file archival manager
         self.archival_manager = FileArchivalManager()
+        self.ffmpeg_path = ensure_ffmpeg_tooling(settings.ffmpeg_path)
 
         logger.info("Video generator initialized with theme management and stock footage support")
 
@@ -547,7 +549,7 @@ class VideoGenerator:
                 pixabay_api_key=settings.pixabay_api_key,
             )
             self._visual_matcher = VisualMatcher()
-            self._broll_generator = BRollGenerator(ffmpeg_path=settings.ffmpeg_path)
+            self._broll_generator = BRollGenerator(ffmpeg_path=self.ffmpeg_path)
 
     def _generate_with_stock_footage(
         self,

--- a/docs/VIDEO_GENERATOR_ERROR_ROOT_CAUSES_JA.md
+++ b/docs/VIDEO_GENERATOR_ERROR_ROOT_CAUSES_JA.md
@@ -1,0 +1,48 @@
+# VideoGeneratorにおけるエラー頻発ポイントと恒久対策案
+
+本ドキュメントでは、運用中に再発している `VideoGenerator` 関連の障害ログを踏まえ、コードの構造から再現性が高い失敗パターンを特定し、恒久対策の方向性を整理する。
+
+## 1. FFmpegバイナリ検出と共有設定の不足
+
+- `VideoGenerator._get_audio_duration` は `AudioSegment.from_file` を呼び出すが、Pydub は内部で FFmpeg バイナリを利用するため、`ffmpeg` がパスに存在しない環境ではここで例外が発生し動画生成全体が停止する。【F:app/video.py†L390-L396】
+- B-roll 生成クラスも同じく FFmpeg を前提としているが、初期化時に `subprocess.run([ffmpeg_path, "-version"])` を試すのみで、失敗しても警告ログで終了してしまうため後続処理まで進んでから致命的に失敗する。【F:app/services/media/broll_generator.py†L24-L35】
+- 設定ロード時に `shutil.which` と `imageio_ffmpeg` による自動検出は行っているが、検出結果を Pydub に伝搬していないため、環境によっては `AudioSegment` が未解決の `ffmpeg` を指し続ける。【F:app/config/settings.py†L336-L360】
+- 実際にユニットテストでも「Couldn't find ffmpeg or avconv」という警告が出ており、エラーの温床になっていることが確認できる。【4356c6†L1-L35】
+
+**恒久対策案**
+1. 設定初期化後に `AudioSegment.converter` と `AudioSegment.ffmpeg` を `settings.ffmpeg_path` に強制的に上書きし、全コンポーネントで同じバイナリを参照させる。
+2. `app.verify` もしくは `FileArchivalManager` と同等の初期化フェーズで `ffmpeg -version` と `ffmpeg -filters` を実行し、失敗時は早期に例外で停止する（警告ではなく必須依存と扱う）。
+3. Docker / systemd 環境に静的 FFmpeg バイナリをバンドルし、`FFMPEG_PATH` を設定ファイルで明示できるようにする。CI 上では `imageio_ffmpeg.get_ffmpeg_exe()` の結果をキャッシュし、欠落時に自動ダウンロードする。
+4. 上記を自動テスト化するため、`pytest` に `@pytest.mark.integration` の初期化チェックを追加し、`settings.ffmpeg_path` で実際に 1 秒の無音動画を生成できるか検証する。
+
+## 2. B-roll クロスフェードフィルタの境界条件不備
+
+- ストック映像を複数結合する場合、クリップごとの長さを `clip_duration = target_duration / len(valid_clips)` と算出し、固定値 `transition_duration=1.0` をそのまま差し引いた `offset` を `xfade` に渡している。【F:app/services/media/broll_generator.py†L81-L98】【F:app/services/media/broll_generator.py†L205-L248】
+- クリップ数が多い／目標尺が短い場合に `clip_duration <= transition_duration` となると `offset` が 0 以下になり、FFmpeg が `xfade` フィルタの引数不正で失敗する。失敗時には例外が投げられ、「Failed to create B-roll sequence」で静止画フォールバックに落ちるため、ストック映像が実質使えなくなる。
+- さらに、`xfade` フィルタは FFmpeg 4.2 以降で追加されたため、旧バージョンではフィルタそのものが存在せず同じく失敗する。現状はバージョン検査を行っていない。
+
+**恒久対策案**
+1. `clip_duration` の 40〜50% を上限として `transition_duration` を自動クリップし、`offset` が常に正になるよう制約を追加する。極端に短い場合はクロスフェード自体をスキップし `concat` ベースに切り替える。
+2. 初期化時に `ffmpeg -filters` を実行して `xfade` の有無を検出し、未対応環境では `create_simple_sequence`（`concat` ベース）に自動ダウングレードする。【F:app/services/media/broll_generator.py†L300-L337】
+3. 失敗時のログだけでなく、`_generate_with_stock_footage` から例外を投げて上位に伝搬させ、運用監視で検出しやすくする。【F:app/video.py†L552-L664】
+4. 代表的な短尺・長尺パターンをカバーするユニットテストを追加し、`transition_duration` の自動調整が効いているか検証する。
+
+## 3. 字幕フォント解決失敗による `subtitles` フィルタエラー
+
+- 字幕の `force_style` を生成する際、`fc-list` で和文フォントを探索し見つからなかった場合は `"Arial"` を返す仕様だが、コンテナ環境では `Arial` が存在しないことが多く、FFmpeg の `subtitles` フィルタが `Fontconfig error` で失敗する原因になる。【F:app/video.py†L414-L516】
+- `fc-list` 自体が存在しない Windows 環境では `subprocess.run` が `FileNotFoundError` を投げ、例外が握りつぶされて `"Arial"` フォールバックに落ちる。結果としてマルチプラットフォームで同じ失敗パターンが再現する。
+
+**恒久対策案**
+1. リポジトリに OSS の日本語フォント（例: Noto Sans CJK）を同梱し、`settings.subtitle_font_path` で明示的にパスを渡せるようにする。`force_style` では `FontName` ではなく `fontsdir`/`fontfile` オプションを使うことで `Fontconfig` に依存しない描画に切り替える。
+2. `fc-list` が利用できない環境では `subprocess.run` をスキップする条件分岐を追加し、フォント解決を OS 判定ベースに切り替える（Windows は `C:\\Windows\\Fonts\\*.ttc` を優先など）。
+3. `app.verify` に字幕フォントの存在チェックを追加し、欠落している場合は起動前に明示的なエラーと対処方法を提示する。
+4. CI で `ffmpeg` を使った 5 秒程度の字幕焼き込みスモークテストを実行し、フォント解決エラーの回帰を検知する。
+
+## 4. 実装ロードマップ（提案）
+
+1. **フェーズ1**: FFmpeg パス統一と起動前検証 (`AudioSegment` 連携、`app.verify` 拡張)。
+2. **フェーズ2**: B-roll クロスフェードの境界条件修正とフィルタ対応状況の自動検出。
+3. **フェーズ3**: 字幕フォント解決の再設計（バンドルフォント導入・設定拡張・CI スモークテスト）。
+4. **フェーズ4**: 上記変更に伴うドキュメント更新と運用 Runbook の改訂。
+
+これらを段階的に実装することで、VideoGenerator の主要な失敗パスを事前に封じ、ストック映像と字幕付き動画の安定稼働を実現できる。

--- a/tests/unit/test_utils_ffmpeg_support.py
+++ b/tests/unit/test_utils_ffmpeg_support.py
@@ -1,0 +1,75 @@
+"""Unit tests for FFmpeg configuration helpers."""
+
+import subprocess
+
+import pytest
+from pydub import AudioSegment
+
+from app.services.media import ffmpeg_support
+
+pytestmark = pytest.mark.unit
+
+
+def _restore_audiosegment(original_converter, original_ffmpeg, original_ffprobe):
+    AudioSegment.converter = original_converter
+    if original_ffmpeg is not None:
+        AudioSegment.ffmpeg = original_ffmpeg
+    elif hasattr(AudioSegment, "ffmpeg"):
+        delattr(AudioSegment, "ffmpeg")
+
+    if original_ffprobe is not None:
+        AudioSegment.ffprobe = original_ffprobe
+    elif hasattr(AudioSegment, "ffprobe"):
+        delattr(AudioSegment, "ffprobe")
+
+
+def test_ensure_ffmpeg_tooling_configures_audiosegment(monkeypatch, tmp_path):
+    """The helper should wire AudioSegment to the validated FFmpeg binaries."""
+
+    ffmpeg_support.ensure_ffmpeg_tooling.cache_clear()
+
+    binary = tmp_path / "ffmpeg"
+    binary.write_text("#!/bin/sh\nexit 0\n")
+
+    ffprobe = tmp_path / "ffprobe"
+    ffprobe.write_text("#!/bin/sh\nexit 0\n")
+
+    def fake_which(candidate: str):
+        if candidate in {"ffmpeg", str(binary)}:
+            return str(binary)
+        if candidate == "ffprobe":
+            return str(ffprobe)
+        return None
+
+    monkeypatch.setattr(ffmpeg_support.shutil, "which", fake_which)
+
+    def fake_run(cmd, capture_output=True, check=True, timeout=5):
+        return subprocess.CompletedProcess(cmd, 0, b"", b"")
+
+    monkeypatch.setattr(ffmpeg_support.subprocess, "run", fake_run)
+
+    original_converter = AudioSegment.converter
+    original_ffmpeg = getattr(AudioSegment, "ffmpeg", None)
+    original_ffprobe = getattr(AudioSegment, "ffprobe", None)
+
+    try:
+        resolved = ffmpeg_support.ensure_ffmpeg_tooling(str(binary))
+        assert resolved == str(binary)
+        assert AudioSegment.converter == str(binary)
+        assert getattr(AudioSegment, "ffmpeg", None) == str(binary)
+        assert getattr(AudioSegment, "ffprobe", None) == str(ffprobe)
+    finally:
+        _restore_audiosegment(original_converter, original_ffmpeg, original_ffprobe)
+        ffmpeg_support.ensure_ffmpeg_tooling.cache_clear()
+
+
+def test_ensure_ffmpeg_tooling_raises_when_binary_missing(monkeypatch):
+    """A missing FFmpeg binary should raise an informative error."""
+
+    ffmpeg_support.ensure_ffmpeg_tooling.cache_clear()
+
+    monkeypatch.setattr(ffmpeg_support.shutil, "which", lambda candidate: None)
+
+    with pytest.raises(FileNotFoundError):
+        ffmpeg_support.ensure_ffmpeg_tooling("/nonexistent/ffmpeg")
+

--- a/tests/unit/test_video_generator_motion.py
+++ b/tests/unit/test_video_generator_motion.py
@@ -14,9 +14,13 @@ pytestmark = pytest.mark.unit
 @pytest.fixture()
 def video_components(monkeypatch):
     """Load app.video with lightweight stubbed workflow steps."""
+    stub_ensure = lambda path=None: "ffmpeg"
+    monkeypatch.setattr("app.services.media.ffmpeg_support.ensure_ffmpeg_tooling", stub_ensure)
+
     preloaded = "app.video" in sys.modules
     if preloaded:
         module = sys.modules["app.video"]
+        monkeypatch.setattr(module, "ensure_ffmpeg_tooling", stub_ensure)
         yield module, module.VideoGenerator
         return
 
@@ -42,6 +46,7 @@ def video_components(monkeypatch):
     monkeypatch.setitem(sys.modules, "app.workflow.steps", stub_steps)
 
     module = importlib.import_module("app.video")
+    monkeypatch.setattr(module, "ensure_ffmpeg_tooling", stub_ensure)
     try:
         yield module, module.VideoGenerator
     finally:


### PR DESCRIPTION
## Summary
- add a shared FFmpeg validation helper that configures pydub to use the resolved binary
- update VideoGenerator and B-roll services to rely on the shared helper for consistent tooling
- add unit tests covering the helper and adjust existing tests to stub the validation hook

## Testing
- pytest tests/unit/test_utils_ffmpeg_support.py -q
- pytest tests/unit/test_video_generator_motion.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e1cf4d25f483258375d9b32805e24e