### PR TITLE
fix: refresh logging session metadata

### DIFF
--- a/app/logging_config.py
+++ b/app/logging_config.py
@@ -136,9 +136,8 @@ class RunContextFilter(logging.Filter):
         self.context.update({k: v for k, v in context.items() if v is not None})
 
     def filter(self, record: logging.LogRecord) -> bool:
-        if not hasattr(record, "session_id"):
-            record.session_id = self.session_id
-        if self.run_id and not hasattr(record, "run_id"):
+        record.session_id = self.session_id
+        if self.run_id is not None:
             record.run_id = self.run_id
         for key, value in self.context.items():
             if not hasattr(record, key):


### PR DESCRIPTION
## Summary
- ensure the logging context filter always injects the active session identifier onto records
- update run identifier propagation without disturbing other contextual extras

## Testing
- pytest tests/unit/test_logging_config.py::test_setup_logging_creates_structured_files -q
- pytest tests/unit/adapters/test_llm_contract.py::test_crewai_gemini_llm_declares_function_calling -q

------
https://chatgpt.com/codex/tasks/task_e_68e1d3adcc948325a80aac3cbcec407e