### PR TITLE
docs: document CrewAI BaseLLM model requirement

### DIFF
--- a/docs/JA_OPERATIONS_GUIDE.md
+++ b/docs/JA_OPERATIONS_GUIDE.md
@@ -133,6 +133,7 @@ uv run python3 -m app.main test
 | 字幕と音声がずれる | `data/qa_reports` の `subtitle_alignment` セクション | `TranscribeAudioStep` を再実行し、音量レベルや `media_quality.subtitles` の閾値を調整。 |
 | 動画生成が失敗する | FFmpeg のエラーログ / `Failed to create B-roll sequence` | 一時的に `stock_footage.enabled=false` にして再実行し、FFmpeg パスとテンプレート画像の有無を確認。 |
 | QA でブロックされる | レポートの `blocking_failures` | 閾値を見直すか、該当ステップ（字幕・音量など）を手動で修正して再実行。 |
+| CrewAI Gemini 起動時に `BaseLLM.__init__() missing 1 required positional argument: 'model'` | `uv run python -m app.verify` のログで CrewAI バージョンが 0.74 以降か確認 | CrewAI 側の `BaseLLM` が `model` 引数を必須化したことが原因。`settings.llm_model` を設定し、`app.adapters.llm.CrewAIGeminiLLM` を最新コミットに更新してから `uv sync` → `app.verify` を再実行。 |
 
 ### 5.2 VideoGenerator で頻発する根本原因
 

--- a/tests/unit/adapters/test_llm_contract.py
+++ b/tests/unit/adapters/test_llm_contract.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+import app.adapters.llm as llm_module
 from app.adapters.llm import GeminiClient, get_crewai_gemini_llm
 
 
@@ -31,3 +32,39 @@ def test_gemini_client_generate_structured_parses_json(monkeypatch):
 
     assert isinstance(result, dict)
     assert result["foo"] == "bar"
+
+
+@pytest.mark.unit
+def test_crewai_gemini_llm_passes_kwargs_supported_by_base(monkeypatch):
+    """CrewAI Gemini LLM should forward compatible kwargs to BaseLLM.__init__."""
+
+    captured: dict = {}
+
+    def fake_init(self, *, model, temperature, api_key=None, custom_flag=None):  # noqa: ANN001
+        captured.update(
+            {
+                "model": model,
+                "temperature": temperature,
+                "api_key": api_key,
+                "custom_flag": custom_flag,
+            }
+        )
+
+    monkeypatch.setattr(llm_module.BaseLLM, "__init__", fake_init)
+
+    llm = llm_module.CrewAIGeminiLLM(
+        model="unit-test",
+        temperature=0.25,
+        stop=["halt"],
+        api_key="key-123",
+        custom_flag="forward-me",
+    )
+
+    assert captured == {
+        "model": "unit-test",
+        "temperature": 0.25,
+        "api_key": "key-123",
+        "custom_flag": "forward-me",
+    }
+    assert llm.stop == ["halt"]
+    assert llm.temperature == 0.25


### PR DESCRIPTION
## Summary
- add troubleshooting guidance for the CrewAI BaseLLM `model` argument requirement in the Japanese operations guide

## Testing
- pytest tests/unit/adapters/test_llm_contract.py

------
https://chatgpt.com/codex/tasks/task_e_68e1db86de3883258add01c4be63f9b1