### PR TITLE
fix: align thumbnail style with selected visual theme

### DIFF
--- a/app/services/visual_design.py
+++ b/app/services/visual_design.py
@@ -6,7 +6,7 @@
 
 import logging
 from dataclasses import dataclass
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple
 
 from app.background_theme import BackgroundTheme, get_theme_manager
 from app.config.paths import ProjectPaths
@@ -39,6 +39,9 @@ class UnifiedVisualDesign:
     primary_color: Tuple[int, int, int]
     accent_color: Tuple[int, int, int]
     text_color: Tuple[int, int, int]
+
+    # サムネイルスタイル
+    thumbnail_style: Optional[str] = None
 
     # フォント設定
     subtitle_font_size: int = 48
@@ -91,6 +94,16 @@ class UnifiedVisualDesign:
             primary = (0, 120, 215)  # 青（信頼）
             accent = (255, 215, 0)  # 金色（クリック誘導）
 
+        theme_to_thumbnail_style = {
+            "professional_blue": "economic_blue",
+            "elegant_purple": "youtube_style",
+            "dynamic_green": "financial_green",
+            "minimal_gray": "economic_blue",
+            "modern_growth": "financial_green",
+            "professional_alert": "market_red",
+        }
+        thumbnail_style = theme_to_thumbnail_style.get(theme.name)
+
         logger.info(f"Selected visual design: theme={theme.name}, sentiment={sentiment}")
 
         return cls(
@@ -100,6 +113,7 @@ class UnifiedVisualDesign:
             primary_color=primary,
             accent_color=accent,
             text_color=(255, 255, 255),  # 白（視認性最強）
+            thumbnail_style=thumbnail_style,
         )
 
     @staticmethod
@@ -175,6 +189,9 @@ class UnifiedVisualDesign:
         Returns:
             str: カラースキーム名 ("economic_blue", "financial_green", "market_red")
         """
+        if self.thumbnail_style:
+            return self.thumbnail_style
+
         if self.sentiment == "positive":
             return "financial_green"
         elif self.sentiment == "negative":
@@ -193,6 +210,7 @@ class UnifiedVisualDesign:
             "primary_color": self.primary_color,
             "accent_color": self.accent_color,
             "text_color": self.text_color,
+            "thumbnail_style": self.get_thumbnail_style(),
             "subtitle_font_size": self.subtitle_font_size,
             "thumbnail_title_font_size": self.thumbnail_title_font_size,
             "robot_icon_enabled": self.robot_icon_enabled,

--- a/tests/unit/test_visual_design.py
+++ b/tests/unit/test_visual_design.py
@@ -1,0 +1,87 @@
+"""Tests for unified visual design thumbnail style selection."""
+
+from app.background_theme import BackgroundTheme
+from app.services import visual_design
+from app.services.visual_design import UnifiedVisualDesign
+
+
+def _make_theme(name: str) -> BackgroundTheme:
+    """Create a minimal BackgroundTheme for testing."""
+
+    return BackgroundTheme(
+        name=name,
+        description="",
+        gradient_stops=[0.25, 0.6, 0.8, 1.0],
+        gradient_colors=[(10, 20, 30), (20, 30, 40), (30, 40, 50), (40, 50, 60), (50, 60, 70)],
+        accent_circles=[],
+        grid_enabled=False,
+        grid_spacing=0,
+        grid_opacity=0,
+        diagonal_lines=False,
+        robot_icon_enabled=True,
+        robot_icon_position="top-left",
+        robot_icon_size=(100, 100),
+        robot_icon_opacity=1.0,
+        title_font_size=60,
+        title_position_y=120,
+        title_shadow_layers=3,
+        title_glow_enabled=False,
+        accent_lines_enabled=False,
+        subtitle_zone_height_ratio=0.8,
+        subtitle_zone_separator=False,
+    )
+
+
+def test_get_thumbnail_style_prefers_theme_mapping():
+    """Explicit thumbnail_style should be returned even if sentiment differs."""
+
+    theme = _make_theme("professional_blue")
+    design = UnifiedVisualDesign(
+        theme_name=theme.name,
+        background_theme=theme,
+        sentiment="positive",
+        primary_color=(0, 0, 0),
+        accent_color=(0, 0, 0),
+        text_color=(255, 255, 255),
+        thumbnail_style="economic_blue",
+    )
+
+    assert design.get_thumbnail_style() == "economic_blue"
+
+
+def test_get_thumbnail_style_falls_back_to_sentiment():
+    """When no theme mapping is present, sentiment fallback is used."""
+
+    theme = _make_theme("professional_blue")
+    design = UnifiedVisualDesign(
+        theme_name=theme.name,
+        background_theme=theme,
+        sentiment="negative",
+        primary_color=(0, 0, 0),
+        accent_color=(0, 0, 0),
+        text_color=(255, 255, 255),
+    )
+
+    assert design.get_thumbnail_style() == "market_red"
+
+
+def test_create_from_news_uses_theme_specific_style(monkeypatch):
+    """create_from_news should attach a theme-appropriate thumbnail style."""
+
+    base_theme = _make_theme("professional_blue")
+
+    class _StubThemeManager:
+        def get_theme(self, name: str):
+            return base_theme if name == base_theme.name else None
+
+        def select_theme_for_ab_test(self):
+            return base_theme
+
+    monkeypatch.setattr(visual_design, "get_theme_manager", lambda: _StubThemeManager())
+
+    news_items = [{"title": "株価が上昇"}]
+    script_content = "世界的に株価が上昇し投資家心理も改善している。"
+
+    design = UnifiedVisualDesign.create_from_news(news_items, script_content, mode="daily")
+
+    assert design.thumbnail_style == "economic_blue"


### PR DESCRIPTION
## Summary
- persist the thumbnail style selected by the unified visual design so thumbnails mirror the chosen theme
- fall back to sentiment-based colors only when a theme-specific style is unavailable and expose the style in the context dict
- add unit coverage ensuring theme mappings and sentiment fallback behave as expected

## Testing
- pytest tests/unit/test_visual_design.py

------
https://chatgpt.com/codex/tasks/task_e_68e1f23d89908325b0ec945cf75e4f21