### PR TITLE
test: cover fallback subtitle rendering

### DIFF
--- a/tests/integration/test_video_fallback_render.py
+++ b/tests/integration/test_video_fallback_render.py
@@ -1,0 +1,69 @@
+import math
+import shutil
+import struct
+import wave
+from pathlib import Path
+
+import ffmpeg
+import pytest
+from PIL import Image
+
+from app.video import VideoGenerator
+
+
+def _write_sine_wave(path: Path, duration: float = 1.0, frequency: float = 440.0, sample_rate: int = 44100) -> None:
+    """Create a small WAV file for testing."""
+    amplitude = 0.3
+    total_frames = int(sample_rate * duration)
+
+    with wave.open(str(path), "w") as wav_file:
+        wav_file.setnchannels(1)
+        wav_file.setsampwidth(2)
+        wav_file.setframerate(sample_rate)
+
+        for frame_index in range(total_frames):
+            sample = math.sin(2 * math.pi * frequency * frame_index / sample_rate)
+            value = int(32767 * amplitude * sample)
+            wav_file.writeframes(struct.pack("<h", value))
+
+
+@pytest.mark.integration
+def test_fallback_video_burns_subtitles_with_style(tmp_path, monkeypatch):
+    if shutil.which("ffmpeg") is None:
+        pytest.skip("ffmpeg binary required for fallback rendering test")
+
+    generator = VideoGenerator()
+    monkeypatch.chdir(tmp_path)
+
+    audio_path = tmp_path / "tone.wav"
+    _write_sine_wave(audio_path)
+
+    subtitle_path = tmp_path / "subtitles.srt"
+    subtitle_path.write_text("1\n00:00:00,000 --> 00:00:01,000\nテスト字幕\n", encoding="utf-8")
+
+    output_path = generator._generate_fallback_video(str(audio_path), str(subtitle_path), "テストタイトル")
+
+    assert output_path, "Fallback video path should be returned"
+    output_file = Path(output_path)
+    assert output_file.exists(), "Fallback video file should exist"
+
+    frame_path = tmp_path / "frame.png"
+    (
+        ffmpeg
+        .input(str(output_file), ss=0.5)
+        .output(str(frame_path), vframes=1)
+        .overwrite_output()
+        .run(quiet=True)
+    )
+
+    assert frame_path.exists(), "Expected snapshot frame from fallback video"
+
+    with Image.open(frame_path) as frame:
+        bottom_region = frame.crop((0, frame.height - 240, frame.width, frame.height))
+        bright_pixel_found = any(
+            sum(bottom_region.getpixel((x, y))) / 3 > 200
+            for x in range(0, bottom_region.width, 6)
+            for y in range(0, bottom_region.height, 6)
+        )
+
+    assert bright_pixel_found, "Expected bright subtitle pixels in fallback video frame"

--- a/tests/unit/test_video_fallback.py
+++ b/tests/unit/test_video_fallback.py
@@ -1,0 +1,66 @@
+from pathlib import Path
+
+import pytest
+
+import app.video as video_module
+from app.video import VideoGenerator
+
+
+class DummyStream:
+    def __init__(self, name: str, applied_filters: list):
+        self.name = name
+        self._applied_filters = applied_filters
+
+    def filter(self, *args, **kwargs):
+        self._applied_filters.append((args, kwargs))
+        return self
+
+    def overwrite_output(self):
+        return self
+
+
+class DummyOutput(DummyStream):
+    pass
+
+
+@pytest.mark.unit
+def test_fallback_video_attempts_to_burn_subtitles(monkeypatch, tmp_path):
+    generator = VideoGenerator()
+
+    subtitle_path = tmp_path / "subtitles.srt"
+    subtitle_path.write_text("1\n00:00:00,000 --> 00:00:01,000\nテスト\n")
+
+    audio_path = tmp_path / "audio.wav"
+    audio_path.write_text("fake audio")
+
+    applied_filters = []
+
+    def fake_input(source, **kwargs):
+        if isinstance(source, str) and source.startswith("color="):
+            return DummyStream("video", applied_filters)
+        if Path(source) == audio_path:
+            return DummyStream("audio", applied_filters)
+        raise AssertionError(f"Unexpected input source: {source}")
+
+    def fake_output(video_stream, audio_stream, output_path, **kwargs):
+        assert isinstance(video_stream, DummyStream)
+        assert audio_stream.name == "audio"
+        assert output_path.endswith(".mp4")
+        return DummyOutput("output", applied_filters)
+
+    def fake_run(stream, quiet=True):
+        assert isinstance(stream, DummyOutput)
+
+    monkeypatch.setattr(generator, "_get_audio_duration", lambda _path: 1.0)
+    monkeypatch.setattr(generator, "_build_subtitle_style", lambda: "FontName=Dummy")
+    monkeypatch.setattr(generator, "_normalize_subtitle_path", lambda path: str(path))
+    monkeypatch.setattr(video_module.ffmpeg, "input", fake_input)
+    monkeypatch.setattr(video_module.ffmpeg, "output", fake_output)
+    monkeypatch.setattr(video_module.ffmpeg, "run", fake_run)
+
+    generator._generate_fallback_video(str(audio_path), str(subtitle_path), "title")
+
+    assert any(
+        args and args[0] == "subtitles" and args[1] == str(subtitle_path)
+        for args, _ in applied_filters
+    )


### PR DESCRIPTION
## Summary
- add an integration test that exercises the fallback renderer end-to-end and inspects a captured frame for subtitle pixels when ffmpeg is available

## Testing
- pytest tests/unit/test_video_fallback.py
- pytest tests/integration/test_video_fallback_render.py

------
https://chatgpt.com/codex/tasks/task_e_68e1f247678483259b7011dab6632943