### PR TITLE
fix: use imageio ffmpeg fallback

### DIFF
--- a/tests/unit/test_utils_ffmpeg_support.py
+++ b/tests/unit/test_utils_ffmpeg_support.py
@@ -1,7 +1,5 @@
 """Unit tests for FFmpeg configuration helpers."""
 
-import subprocess
-
 import pytest
 from pydub import AudioSegment
 
@@ -43,10 +41,7 @@ def test_ensure_ffmpeg_tooling_configures_audiosegment(monkeypatch, tmp_path):
 
     monkeypatch.setattr(ffmpeg_support.shutil, "which", fake_which)
 
-    def fake_run(cmd, capture_output=True, check=True, timeout=5):
-        return subprocess.CompletedProcess(cmd, 0, b"", b"")
-
-    monkeypatch.setattr(ffmpeg_support.subprocess, "run", fake_run)
+    monkeypatch.setattr(ffmpeg_support, "_run_ffmpeg_command", lambda cmd: None)
 
     original_converter = AudioSegment.converter
     original_ffmpeg = getattr(AudioSegment, "ffmpeg", None)
@@ -72,4 +67,32 @@ def test_ensure_ffmpeg_tooling_raises_when_binary_missing(monkeypatch):
 
     with pytest.raises(FileNotFoundError):
         ffmpeg_support.ensure_ffmpeg_tooling("/nonexistent/ffmpeg")
+
+
+def test_ensure_ffmpeg_tooling_falls_back_to_imageio(monkeypatch, tmp_path):
+    """The helper should resolve FFmpeg via imageio-ffmpeg when available."""
+
+    ffmpeg_support.ensure_ffmpeg_tooling.cache_clear()
+
+    monkeypatch.setattr(ffmpeg_support.shutil, "which", lambda candidate: None)
+
+    fallback = tmp_path / "ffmpeg"
+    fallback.write_text("#!/bin/sh\nexit 0\n")
+    fallback.chmod(0o755)
+
+    monkeypatch.setattr(ffmpeg_support, "get_ffmpeg_exe", lambda: str(fallback))
+    monkeypatch.setattr(ffmpeg_support, "_run_ffmpeg_command", lambda cmd: None)
+
+    original_converter = AudioSegment.converter
+    original_ffmpeg = getattr(AudioSegment, "ffmpeg", None)
+    original_ffprobe = getattr(AudioSegment, "ffprobe", None)
+
+    try:
+        resolved = ffmpeg_support.ensure_ffmpeg_tooling()
+        assert resolved == str(fallback)
+        assert AudioSegment.converter == str(fallback)
+        assert getattr(AudioSegment, "ffmpeg", None) == str(fallback)
+    finally:
+        _restore_audiosegment(original_converter, original_ffmpeg, original_ffprobe)
+        ffmpeg_support.ensure_ffmpeg_tooling.cache_clear()
 


### PR DESCRIPTION
## Summary
- rely on imageio-ffmpeg to resolve a real FFmpeg binary when the configured path is missing
- keep AudioSegment wired to the discovered executable while logging the fallback
- extend unit coverage to exercise the imageio-ffmpeg resolution path

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e1fa7d9a0c83258c60dfd0f79e498b