### PR TITLE
fix: relax minimum dialogue line enforcement

### DIFF
--- a/app/services/script/validator.py
+++ b/app/services/script/validator.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 import re
 from collections import Counter
 from dataclasses import dataclass
@@ -172,7 +173,16 @@ def ensure_dialogue_structure(
     normalized_script = "\n".join(normalized_lines)
     errors: List[ScriptValidationIssue] = []
 
-    if dialogue_line_count < max(min_dialogue_lines, int(nonempty_line_count * min_dialogue_ratio)):
+    required_by_ratio = math.ceil(nonempty_line_count * min_dialogue_ratio)
+    if nonempty_line_count:
+        required_by_ratio = max(1, required_by_ratio)
+    required_by_ratio = min(required_by_ratio, nonempty_line_count)
+
+    required_by_count = min(min_dialogue_lines, nonempty_line_count)
+
+    minimum_required = max(required_by_ratio, required_by_count)
+
+    if dialogue_line_count < minimum_required:
         errors.append(
             ScriptValidationIssue(
                 0,

--- a/tests/unit/test_script_format_validator.py
+++ b/tests/unit/test_script_format_validator.py
@@ -80,3 +80,18 @@ def test_validator_handles_honorifics_and_aliases():
     assert result.speaker_counts["武宏"] == 1
     assert result.speaker_counts["つむぎ"] == 1
     assert result.speaker_counts["ナレーター"] == 1
+
+
+def test_validator_allows_short_form_scripts_when_all_lines_are_dialogue():
+    script = "\n".join(
+        [
+            "武宏: 速報です。",
+            "つむぎ: 詳細を教えてください。",
+        ]
+    )
+
+    result = ensure_dialogue_structure(script, allowed_speakers=ALLOWED)
+
+    assert result.dialogue_line_count == 2
+    assert result.nonempty_line_count == 2
+    assert result.is_valid


### PR DESCRIPTION
## Summary
- cap the minimum required dialogue lines by the available non-empty lines when validating scripts
- add a regression test to ensure short two-line dialogues are accepted by the validator

## Testing
- pytest tests/unit/test_script_format_validator.py

------
https://chatgpt.com/codex/tasks/task_e_68e1ffcad2f08325947a9fa737cf4769