### PR TITLE
fix: parse JSON blocks with embedded braces

### DIFF
--- a/app/services/script/generator.py
+++ b/app/services/script/generator.py
@@ -334,13 +334,36 @@ class StructuredScriptGenerator:
     @staticmethod
     def _find_matching_brace(text: str) -> Optional[int]:
         depth = 0
+        in_string = False
+        escape = False
+
         for idx, char in enumerate(text):
+            if in_string:
+                if escape:
+                    escape = False
+                    continue
+
+                if char == "\\":
+                    escape = True
+                    continue
+
+                if char == '"':
+                    in_string = False
+                continue
+
+            if char == '"':
+                in_string = True
+                continue
+
             if char == "{":
                 depth += 1
-            elif char == "}":
+                continue
+
+            if char == "}":
                 depth -= 1
                 if depth == 0:
                     return idx
+
         return None
 
     @staticmethod


### PR DESCRIPTION
## Summary
- ignore curly braces inside quoted strings when scanning LLM responses for structured JSON payloads
- add a regression test covering braces within dialogue text and relax fallback assertions accordingly

## Testing
- python -m pytest tests/unit/test_structured_script_generator.py


------
https://chatgpt.com/codex/tasks/task_e_68e201787a20832582867b80862b395c