### PR TITLE
feat: build tauri job control dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ downloads/
 eggs/
 .eggs/
 lib/
+!tauri-app/src/lib/
+!tauri-app/src/lib/**
 lib64/
 parts/
 sdist/

--- a/tauri-app/.gitignore
+++ b/tauri-app/.gitignore
@@ -22,5 +22,6 @@ Thumbs.db
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 *ico*
+!src/lib/assets/favicon.svg
 *csv*
 *md*

--- a/tauri-app/src/lib/apiClient.ts
+++ b/tauri-app/src/lib/apiClient.ts
@@ -1,0 +1,68 @@
+import type { CommandDefinition, JobSummary, LogEvent } from './types';
+
+const DEFAULT_BASE_URL = 'http://localhost:8000';
+
+function resolveBaseUrl(): string {
+    const configured = import.meta.env.VITE_GUI_API_BASE as string | undefined;
+    return configured?.replace(/\/$/, '') || DEFAULT_BASE_URL;
+}
+
+function buildUrl(path: string): string {
+    const base = resolveBaseUrl();
+    const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+    return `${base}${normalizedPath}`;
+}
+
+async function fetchJson<T>(path: string, init?: RequestInit): Promise<T> {
+    const response = await fetch(buildUrl(path), {
+        ...init,
+        headers: {
+            'Content-Type': 'application/json',
+            ...(init?.headers ?? {})
+        }
+    });
+
+    if (!response.ok) {
+        const detail = await response.text().catch(() => '');
+        throw new Error(`API request failed with status ${response.status}: ${detail}`);
+    }
+
+    return (await response.json()) as T;
+}
+
+export async function listCommands(): Promise<CommandDefinition[]> {
+    return fetchJson<CommandDefinition[]>('/commands');
+}
+
+export async function createJob(payload: {
+    command_id: string;
+    params?: Record<string, unknown>;
+}): Promise<JobSummary> {
+    return fetchJson<JobSummary>('/jobs', {
+        method: 'POST',
+        body: JSON.stringify(payload)
+    });
+}
+
+export async function getJob(jobId: string): Promise<JobSummary> {
+    return fetchJson<JobSummary>(`/jobs/${jobId}`);
+}
+
+export async function getJobLogs(jobId: string, tail = 200): Promise<LogEvent[]> {
+    const params = new URLSearchParams({ tail: tail.toString() });
+    return fetchJson<LogEvent[]>(`/jobs/${jobId}/logs?${params.toString()}`);
+}
+
+export function connectJobStream(jobId: string): WebSocket {
+    const url = new URL(buildUrl(`/jobs/${jobId}/stream`));
+    url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
+    return new WebSocket(url);
+}
+
+export type ApiClient = {
+    listCommands: typeof listCommands;
+    createJob: typeof createJob;
+    getJob: typeof getJob;
+    getJobLogs: typeof getJobLogs;
+    connectJobStream: typeof connectJobStream;
+};

--- a/tauri-app/src/lib/assets/favicon.svg
+++ b/tauri-app/src/lib/assets/favicon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="12" fill="#111827" />
+  <path d="M18 42V22c0-2.761 2.239-5 5-5h18c2.761 0 5 2.239 5 5v20" stroke="#38BDF8" stroke-width="4" stroke-linecap="round" />
+  <path d="M24 32h16" stroke="#F97316" stroke-width="4" stroke-linecap="round" />
+  <path d="M24 24h16" stroke="#FACC15" stroke-width="4" stroke-linecap="round" />
+  <path d="M24 40h10" stroke="#34D399" stroke-width="4" stroke-linecap="round" />
+</svg>

--- a/tauri-app/src/lib/components/JobLauncher.svelte
+++ b/tauri-app/src/lib/components/JobLauncher.svelte
@@ -1,0 +1,357 @@
+<script lang="ts">
+    import { createEventDispatcher, onMount } from 'svelte';
+    import type { CommandDefinition, CommandParameterSchema } from '$lib/types';
+
+    export let commands: CommandDefinition[] = [];
+    export let loading = false;
+    export let launching = false;
+    export let error: string | null = null;
+
+    const dispatch = createEventDispatcher<{
+        launch: { commandId: string; params: Record<string, unknown> };
+        refresh: void;
+    }>();
+
+    let selectedCommandId: string | null = null;
+    let params: Record<string, unknown> = {};
+    let paramsVersion = '';
+
+    onMount(() => {
+        if (!selectedCommandId && commands.length > 0) {
+            selectedCommandId = commands[0].id;
+        }
+    });
+
+    $: if (!selectedCommandId && commands.length > 0) {
+        selectedCommandId = commands[0].id;
+    }
+
+    $: selectedCommand = commands.find((cmd) => cmd.id === selectedCommandId) ?? null;
+
+    $: {
+        const versionKey = selectedCommand ? selectedCommand.id : '';
+        if (versionKey !== paramsVersion) {
+            params = buildDefaultParams(selectedCommand?.params_schema);
+            paramsVersion = versionKey;
+        }
+    }
+
+    $: parameterEntries = Object.entries(selectedCommand?.params_schema?.properties ?? {});
+    $: requiredSet = new Set(selectedCommand?.params_schema?.required ?? []);
+
+    function buildDefaultParams(schema?: CommandParameterSchema | undefined): Record<string, unknown> {
+        if (!schema || schema.type !== 'object' || !schema.properties) {
+            return {};
+        }
+        const defaults: Record<string, unknown> = {};
+        for (const [key, definition] of Object.entries(schema.properties)) {
+            if (definition.default !== undefined) {
+                defaults[key] = definition.default;
+            } else if (definition.enum && definition.enum.length > 0) {
+                defaults[key] = definition.enum[0];
+            } else if (definition.type === 'boolean') {
+                defaults[key] = false;
+            } else if (definition.type === 'number' || definition.type === 'integer') {
+                defaults[key] = 0;
+            } else {
+                defaults[key] = '';
+            }
+        }
+        return defaults;
+    }
+
+    function handleSubmit(event: Event): void {
+        event.preventDefault();
+        if (!selectedCommandId) {
+            return;
+        }
+        dispatch('launch', { commandId: selectedCommandId, params });
+    }
+
+    function updateParam(key: string, value: unknown): void {
+        params = { ...params, [key]: value };
+    }
+
+    function asString(value: unknown): string {
+        if (value === null || value === undefined) {
+            return '';
+        }
+        return String(value);
+    }
+
+    function parseNumber(value: string): number | null {
+        if (value.trim() === '') {
+            return null;
+        }
+        const parsed = Number(value);
+        return Number.isNaN(parsed) ? null : parsed;
+    }
+</script>
+
+<section class="launcher">
+    <header class="launcher__header">
+        <div>
+            <h2>ジョブランチャー</h2>
+            <p class="launcher__subtitle">CrewAIワークフローや検証コマンドを1クリックで起動します。</p>
+        </div>
+        <button class="ghost" type="button" on:click={() => dispatch('refresh')} disabled={loading}>
+            {loading ? '更新中…' : 'コマンド再取得'}
+        </button>
+    </header>
+
+    {#if error}
+        <div class="launcher__alert">
+            <p>{error}</p>
+        </div>
+    {/if}
+
+    <form class="launcher__form" on:submit={handleSubmit}>
+        <label class="launcher__label" for="command">コマンド</label>
+        <select
+            id="command"
+            bind:value={selectedCommandId}
+            disabled={loading || launching || commands.length === 0}
+        >
+            {#each commands as command}
+                <option value={command.id}>{command.label}</option>
+            {/each}
+        </select>
+
+        {#if selectedCommand}
+            <p class="launcher__description">{selectedCommand.description}</p>
+        {/if}
+
+        {#if parameterEntries.length > 0}
+            <div class="launcher__parameters">
+                <h3>パラメータ</h3>
+                <ul>
+                    {#each parameterEntries as [key, schema]}
+                        <li>
+                            <label for={`param-${key}`}>
+                                <span class="param-label">{schema.title ?? key}</span>
+                                {#if schema.description}
+                                    <span class="param-help">{schema.description}</span>
+                                {/if}
+                                {#if requiredSet.has(key)}
+                                    <span class="param-required">必須</span>
+                                {/if}
+                            </label>
+
+                            {#if schema.enum}
+                                <select
+                                    id={`param-${key}`}
+                                    value={asString(params[key])}
+                                    on:change={(event) => updateParam(key, (event.target as HTMLSelectElement).value)}
+                                >
+                                    {#each schema.enum as choice}
+                                        <option value={choice}>{choice}</option>
+                                    {/each}
+                                </select>
+                            {:else if schema.type === 'boolean'}
+                                <label class="checkbox">
+                                    <input
+                                        id={`param-${key}`}
+                                        type="checkbox"
+                                        checked={Boolean(params[key])}
+                                        on:change={(event) => updateParam(key, (event.target as HTMLInputElement).checked)}
+                                    />
+                                    <span>有効にする</span>
+                                </label>
+                            {:else if schema.type === 'number' || schema.type === 'integer'}
+                                <input
+                                    id={`param-${key}`}
+                                    type="number"
+                                    value={asString(params[key])}
+                                    on:input={(event) => updateParam(key, parseNumber((event.target as HTMLInputElement).value))}
+                                />
+                            {:else}
+                                <input
+                                    id={`param-${key}`}
+                                    type="text"
+                                    value={asString(params[key])}
+                                    on:input={(event) => updateParam(key, (event.target as HTMLInputElement).value)}
+                                />
+                            {/if}
+                        </li>
+                    {/each}
+                </ul>
+            </div>
+        {/if}
+
+        <div class="launcher__actions">
+            <button type="submit" class="primary" disabled={launching || loading || !selectedCommandId}>
+                {launching ? '起動中…' : 'ジョブを開始'}
+            </button>
+        </div>
+    </form>
+</section>
+
+<style>
+    .launcher {
+        display: flex;
+        flex-direction: column;
+        gap: 1.5rem;
+        padding: 1.5rem;
+        border-radius: 16px;
+        background: rgba(17, 24, 39, 0.92);
+        color: #f9fafb;
+        box-shadow: 0 25px 50px -12px rgba(15, 23, 42, 0.55);
+    }
+
+    .launcher__header {
+        display: flex;
+        justify-content: space-between;
+        gap: 1rem;
+        align-items: flex-start;
+    }
+
+    .launcher__header h2 {
+        margin: 0;
+        font-size: 1.5rem;
+    }
+
+    .launcher__subtitle {
+        margin: 0.25rem 0 0;
+        font-size: 0.95rem;
+        color: rgba(226, 232, 240, 0.85);
+    }
+
+    .launcher__alert {
+        padding: 0.75rem 1rem;
+        border-radius: 12px;
+        background: rgba(251, 191, 36, 0.1);
+        border: 1px solid rgba(251, 191, 36, 0.4);
+        color: #facc15;
+        font-size: 0.9rem;
+    }
+
+    .launcher__form {
+        display: flex;
+        flex-direction: column;
+        gap: 1.25rem;
+    }
+
+    .launcher__label {
+        font-weight: 600;
+        font-size: 0.95rem;
+    }
+
+    select,
+    input[type='text'],
+    input[type='number'] {
+        width: 100%;
+        padding: 0.65rem 0.75rem;
+        border-radius: 10px;
+        border: 1px solid rgba(148, 163, 184, 0.4);
+        background: rgba(15, 23, 42, 0.85);
+        color: #e2e8f0;
+        font-size: 0.95rem;
+    }
+
+    select:focus,
+    input:focus {
+        outline: none;
+        border-color: #38bdf8;
+        box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.25);
+    }
+
+    .launcher__description {
+        margin: -0.5rem 0 0;
+        font-size: 0.9rem;
+        color: rgba(226, 232, 240, 0.75);
+    }
+
+    .launcher__parameters ul {
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+        list-style: none;
+        padding: 0;
+        margin: 0;
+    }
+
+    .launcher__parameters h3 {
+        margin: 0 0 0.5rem;
+        font-size: 1.05rem;
+    }
+
+    .param-label {
+        font-weight: 600;
+        display: block;
+    }
+
+    .param-help {
+        display: block;
+        font-size: 0.8rem;
+        color: rgba(226, 232, 240, 0.6);
+        margin-top: 0.25rem;
+    }
+
+    .param-required {
+        background: rgba(248, 113, 113, 0.15);
+        border: 1px solid rgba(248, 113, 113, 0.4);
+        color: #f87171;
+        border-radius: 9999px;
+        font-size: 0.7rem;
+        padding: 0.1rem 0.5rem;
+        margin-left: 0.5rem;
+    }
+
+    .checkbox {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        font-size: 0.95rem;
+    }
+
+    .checkbox input {
+        width: auto;
+        accent-color: #38bdf8;
+    }
+
+    .launcher__actions {
+        display: flex;
+        justify-content: flex-end;
+    }
+
+    button.primary {
+        padding: 0.7rem 1.4rem;
+        border-radius: 12px;
+        border: none;
+        background: linear-gradient(135deg, #38bdf8, #6366f1);
+        color: white;
+        font-weight: 600;
+        cursor: pointer;
+        transition: transform 0.15s ease, box-shadow 0.15s ease;
+    }
+
+    button.primary:disabled {
+        opacity: 0.6;
+        cursor: not-allowed;
+        box-shadow: none;
+    }
+
+    button.primary:not(:disabled):hover {
+        transform: translateY(-1px);
+        box-shadow: 0 12px 30px -10px rgba(56, 189, 248, 0.6);
+    }
+
+    button.ghost {
+        padding: 0.55rem 1rem;
+        border-radius: 10px;
+        border: 1px solid rgba(148, 163, 184, 0.4);
+        background: transparent;
+        color: rgba(226, 232, 240, 0.9);
+        cursor: pointer;
+        font-weight: 500;
+    }
+
+    button.ghost:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+    }
+
+    button.ghost:not(:disabled):hover {
+        border-color: rgba(148, 163, 184, 0.8);
+    }
+</style>

--- a/tauri-app/src/lib/components/JobMonitor.svelte
+++ b/tauri-app/src/lib/components/JobMonitor.svelte
@@ -1,0 +1,484 @@
+<script lang="ts">
+    import { createEventDispatcher } from 'svelte';
+    import type { CommandDefinition, JobSummary, LogEvent } from '$lib/types';
+
+    export let jobs: JobSummary[] = [];
+    export let selectedJobId: string | null = null;
+    export let logs: LogEvent[] = [];
+    export let commands: Record<string, CommandDefinition> = {};
+
+    const dispatch = createEventDispatcher<{ select: { jobId: string } }>();
+
+    $: selectedJob = jobs.find((job) => job.id === selectedJobId) ?? null;
+
+    function formatDate(value?: string | null): string {
+        if (!value) return '-';
+        const date = new Date(value);
+        if (Number.isNaN(date.getTime())) {
+            return value;
+        }
+        return new Intl.DateTimeFormat('ja-JP', {
+            hour: '2-digit',
+            minute: '2-digit',
+            second: '2-digit'
+        }).format(date);
+    }
+
+    function formatStatus(status: JobSummary['status']): string {
+        switch (status) {
+            case 'pending':
+                return '待機中';
+            case 'running':
+                return '実行中';
+            case 'succeeded':
+                return '完了';
+            case 'failed':
+                return '失敗';
+            case 'cancelled':
+                return 'キャンセル';
+            default:
+                return status;
+        }
+    }
+
+    function statusTone(status: JobSummary['status']): string {
+        if (status === 'succeeded') return 'success';
+        if (status === 'failed') return 'danger';
+        if (status === 'running') return 'running';
+        return 'neutral';
+    }
+
+    function handleSelect(jobId: string): void {
+        dispatch('select', { jobId });
+    }
+</script>
+
+<section class="monitor">
+    <header class="monitor__header">
+        <div>
+            <h2>実行モニタ</h2>
+            <p class="monitor__subtitle">進行中/完了済みのジョブを追跡し、ログをリアルタイムに確認できます。</p>
+        </div>
+    </header>
+
+    <div class="monitor__body">
+        <aside class="monitor__jobs">
+            <h3>ジョブ履歴</h3>
+            {#if jobs.length === 0}
+                <p class="monitor__empty">まだジョブがありません。左側からジョブを開始してください。</p>
+            {:else}
+                <ul>
+                    {#each jobs as job}
+                        <li class:selected={job.id === selectedJobId}>
+                            <button type="button" on:click={() => handleSelect(job.id)}>
+                                <div class={`status-badge status-badge--${statusTone(job.status)}`}>
+                                    {formatStatus(job.status)}
+                                </div>
+                                <div class="job-meta">
+                                    <span class="job-command">{commands[job.command_id]?.label ?? job.command_id}</span>
+                                    <span class="job-time">開始 {formatDate(job.started_at ?? job.created_at)}</span>
+                                </div>
+                            </button>
+                        </li>
+                    {/each}
+                </ul>
+            {/if}
+        </aside>
+
+        <article class="monitor__details">
+            {#if selectedJob}
+                <header class="details__header">
+                    <div>
+                        <h3>{commands[selectedJob.command_id]?.label ?? selectedJob.command_id}</h3>
+                        <p class="details__status">{formatStatus(selectedJob.status)}</p>
+                    </div>
+                    <div class={`status-pill status-pill--${statusTone(selectedJob.status)}`}>
+                        {formatStatus(selectedJob.status)}
+                    </div>
+                </header>
+
+                <dl class="details__grid">
+                    <div>
+                        <dt>ジョブID</dt>
+                        <dd>{selectedJob.id}</dd>
+                    </div>
+                    <div>
+                        <dt>開始</dt>
+                        <dd>{formatDate(selectedJob.started_at ?? selectedJob.created_at)}</dd>
+                    </div>
+                    <div>
+                        <dt>終了</dt>
+                        <dd>{formatDate(selectedJob.finished_at)}</dd>
+                    </div>
+                    <div>
+                        <dt>ステータス</dt>
+                        <dd>{formatStatus(selectedJob.status)}</dd>
+                    </div>
+                    <div class="details__full">
+                        <dt>パラメータ</dt>
+                        <dd>
+                            <pre>{JSON.stringify(selectedJob.params ?? {}, null, 2)}</pre>
+                        </dd>
+                    </div>
+                    {#if selectedJob.message}
+                        <div class="details__full">
+                            <dt>メッセージ</dt>
+                            <dd>{selectedJob.message}</dd>
+                        </div>
+                    {/if}
+                </dl>
+
+                <section class="log-viewer">
+                    <header>
+                        <h4>ライブログ</h4>
+                        <span>{logs.length}件</span>
+                    </header>
+                    <div class="log-viewer__scroller">
+                        {#if logs.length === 0}
+                            <p class="monitor__empty">ログはまだありません。ジョブの開始を待機しています。</p>
+                        {:else}
+                            <ul>
+                                {#each logs as log (log.ts + log.line + log.level)}
+                                    <li class={`log log--${log.level}`}>
+                                        <span class="log__ts">{formatDate(log.ts)}</span>
+                                        <span class="log__level">{log.level.toUpperCase()}</span>
+                                        <span class="log__line">{log.line}</span>
+                                    </li>
+                                {/each}
+                            </ul>
+                        {/if}
+                    </div>
+                </section>
+            {:else}
+                <div class="monitor__placeholder">
+                    <p>ジョブを選択すると詳細とログが表示されます。</p>
+                </div>
+            {/if}
+        </article>
+    </div>
+</section>
+
+<style>
+    .monitor {
+        display: flex;
+        flex-direction: column;
+        gap: 1.25rem;
+        padding: 1.5rem;
+        border-radius: 16px;
+        background: rgba(15, 23, 42, 0.75);
+        color: #e2e8f0;
+        border: 1px solid rgba(148, 163, 184, 0.2);
+        min-height: 100%;
+    }
+
+    .monitor__header h2 {
+        margin: 0;
+        font-size: 1.4rem;
+    }
+
+    .monitor__subtitle {
+        margin: 0.2rem 0 0;
+        color: rgba(226, 232, 240, 0.7);
+        font-size: 0.9rem;
+    }
+
+    .monitor__body {
+        display: grid;
+        grid-template-columns: 240px 1fr;
+        gap: 1.25rem;
+        min-height: 24rem;
+    }
+
+    .monitor__jobs {
+        background: rgba(15, 23, 42, 0.55);
+        border-radius: 14px;
+        padding: 1rem;
+        border: 1px solid rgba(148, 163, 184, 0.2);
+    }
+
+    .monitor__jobs h3 {
+        margin: 0 0 0.75rem;
+        font-size: 1.05rem;
+    }
+
+    .monitor__jobs ul {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+    }
+
+    .monitor__jobs li {
+        border-radius: 12px;
+        padding: 0.75rem;
+        background: rgba(30, 41, 59, 0.7);
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+        border: 1px solid transparent;
+        cursor: default;
+        transition: border-color 0.2s ease, transform 0.2s ease;
+    }
+
+    .monitor__jobs li.selected {
+        border-color: rgba(56, 189, 248, 0.6);
+        transform: translateY(-2px);
+    }
+
+    .monitor__jobs li:hover {
+        border-color: rgba(148, 163, 184, 0.6);
+    }
+
+    .monitor__jobs li button {
+        all: unset;
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+        width: 100%;
+        text-align: left;
+        cursor: pointer;
+    }
+
+    .monitor__jobs li button:focus-visible {
+        outline: 2px solid rgba(56, 189, 248, 0.6);
+        outline-offset: 2px;
+    }
+
+    .status-badge {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 0.75rem;
+        font-weight: 600;
+        padding: 0.15rem 0.6rem;
+        border-radius: 9999px;
+        width: fit-content;
+    }
+
+    .status-badge--running {
+        background: rgba(56, 189, 248, 0.2);
+        color: #38bdf8;
+    }
+
+    .status-badge--success {
+        background: rgba(74, 222, 128, 0.2);
+        color: #4ade80;
+    }
+
+    .status-badge--danger {
+        background: rgba(248, 113, 113, 0.2);
+        color: #f87171;
+    }
+
+    .status-badge--neutral {
+        background: rgba(148, 163, 184, 0.2);
+        color: #cbd5f5;
+    }
+
+    .job-meta {
+        display: flex;
+        flex-direction: column;
+        gap: 0.2rem;
+    }
+
+    .job-command {
+        font-weight: 600;
+    }
+
+    .job-time {
+        font-size: 0.8rem;
+        color: rgba(148, 163, 184, 0.9);
+    }
+
+    .monitor__details {
+        background: rgba(15, 23, 42, 0.55);
+        border-radius: 14px;
+        padding: 1.25rem;
+        border: 1px solid rgba(148, 163, 184, 0.2);
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+    }
+
+    .details__header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+    }
+
+    .details__header h3 {
+        margin: 0;
+        font-size: 1.3rem;
+    }
+
+    .details__status {
+        margin: 0.2rem 0 0;
+        color: rgba(226, 232, 240, 0.7);
+        font-size: 0.9rem;
+    }
+
+    .status-pill {
+        padding: 0.4rem 0.8rem;
+        border-radius: 9999px;
+        font-size: 0.8rem;
+        font-weight: 600;
+        border: 1px solid transparent;
+    }
+
+    .status-pill--running {
+        background: rgba(56, 189, 248, 0.15);
+        border-color: rgba(56, 189, 248, 0.3);
+        color: #38bdf8;
+    }
+
+    .status-pill--success {
+        background: rgba(74, 222, 128, 0.15);
+        border-color: rgba(74, 222, 128, 0.3);
+        color: #4ade80;
+    }
+
+    .status-pill--danger {
+        background: rgba(248, 113, 113, 0.15);
+        border-color: rgba(248, 113, 113, 0.35);
+        color: #f87171;
+    }
+
+    .details__grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+        gap: 1rem;
+    }
+
+    .details__grid div {
+        background: rgba(30, 41, 59, 0.65);
+        border-radius: 12px;
+        padding: 0.8rem;
+        border: 1px solid rgba(148, 163, 184, 0.2);
+    }
+
+    .details__grid dt {
+        font-size: 0.75rem;
+        text-transform: uppercase;
+        color: rgba(148, 163, 184, 0.8);
+        margin: 0 0 0.35rem;
+        letter-spacing: 0.05em;
+    }
+
+    .details__grid dd {
+        margin: 0;
+        font-size: 0.95rem;
+        word-break: break-all;
+    }
+
+    .details__full {
+        grid-column: 1 / -1;
+    }
+
+    .details__full pre {
+        margin: 0;
+        background: rgba(15, 23, 42, 0.8);
+        border-radius: 10px;
+        padding: 0.75rem;
+        overflow-x: auto;
+        font-size: 0.85rem;
+        line-height: 1.4;
+    }
+
+    .log-viewer {
+        background: rgba(30, 41, 59, 0.65);
+        border-radius: 12px;
+        border: 1px solid rgba(148, 163, 184, 0.2);
+        display: flex;
+        flex-direction: column;
+        max-height: 18rem;
+    }
+
+    .log-viewer header {
+        display: flex;
+        justify-content: space-between;
+        padding: 0.75rem 1rem;
+        border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+    }
+
+    .log-viewer__scroller {
+        overflow-y: auto;
+        padding: 0.75rem 1rem;
+    }
+
+    .log-viewer ul {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+    }
+
+    .log {
+        display: grid;
+        grid-template-columns: 90px 80px 1fr;
+        gap: 0.5rem;
+        font-size: 0.85rem;
+        padding: 0.4rem 0.6rem;
+        border-radius: 8px;
+        background: rgba(15, 23, 42, 0.65);
+        border: 1px solid transparent;
+    }
+
+    .log--info {
+        border-color: rgba(59, 130, 246, 0.25);
+    }
+
+    .log--warning {
+        border-color: rgba(251, 191, 36, 0.35);
+    }
+
+    .log--error,
+    .log--critical {
+        border-color: rgba(248, 113, 113, 0.4);
+    }
+
+    .log__ts {
+        color: rgba(148, 163, 184, 0.9);
+    }
+
+    .log__level {
+        font-weight: 600;
+        letter-spacing: 0.05em;
+    }
+
+    .log__line {
+        white-space: pre-wrap;
+    }
+
+    .monitor__empty {
+        margin: 0;
+        color: rgba(148, 163, 184, 0.8);
+        font-size: 0.9rem;
+    }
+
+    .monitor__placeholder {
+        flex: 1;
+        display: grid;
+        place-items: center;
+        color: rgba(148, 163, 184, 0.75);
+        border: 2px dashed rgba(148, 163, 184, 0.25);
+        border-radius: 12px;
+    }
+
+    @media (max-width: 960px) {
+        .monitor__body {
+            grid-template-columns: 1fr;
+        }
+
+        .monitor__jobs {
+            order: 2;
+        }
+
+        .monitor__details {
+            order: 1;
+        }
+    }
+</style>

--- a/tauri-app/src/lib/stores/jobStore.ts
+++ b/tauri-app/src/lib/stores/jobStore.ts
@@ -1,0 +1,364 @@
+import { get, writable } from 'svelte/store';
+import { connectJobStream, createJob, getJob, getJobLogs, listCommands } from '$lib/apiClient';
+import type { CommandDefinition, JobStatus, JobSummary, LogEvent } from '$lib/types';
+
+const commands = writable<CommandDefinition[]>([]);
+const commandsLoading = writable(false);
+const commandsError = writable<string | null>(null);
+
+const jobs = writable<JobSummary[]>([]);
+const jobLogs = writable<Record<string, LogEvent[]>>({});
+const selectedJobId = writable<string | null>(null);
+const launchingJob = writable(false);
+const jobError = writable<string | null>(null);
+
+const fallbackCommands: CommandDefinition[] = [
+    {
+        id: 'daily_workflow',
+        label: 'デイリー自動生成',
+        description: 'uv run python3 -m app.main daily',
+        runner: 'python',
+        params_schema: {
+            type: 'object',
+            properties: {
+                mode: {
+                    type: 'string',
+                    enum: ['daily', 'backfill'],
+                    description: '実行モード (daily/backfill)',
+                    default: 'daily'
+                }
+            },
+            required: ['mode']
+        }
+    },
+    {
+        id: 'verify_config',
+        label: '設定チェック',
+        description: 'uv run python -m app.verify',
+        runner: 'cli',
+        params_schema: {
+            type: 'object',
+            properties: {}
+        }
+    },
+    {
+        id: 'generate_analytics',
+        label: '分析レポート',
+        description: 'python scripts/tasks.py analytics',
+        runner: 'cli',
+        params_schema: {
+            type: 'object',
+            properties: {
+                include_trends: {
+                    type: 'string',
+                    enum: ['enabled', 'disabled'],
+                    description: 'トレンド分析を含めるか',
+                    default: 'enabled'
+                }
+            }
+        }
+    }
+];
+
+const logStreams = new Map<string, WebSocket>();
+const mockJobTimers = new Map<string, () => void>();
+const mockLogIntervals = new Map<string, () => void>();
+
+export async function loadCommands(): Promise<void> {
+    commandsLoading.set(true);
+    commandsError.set(null);
+    try {
+        const remote = await listCommands();
+        if (!remote || remote.length === 0) {
+            commands.set(fallbackCommands);
+            commandsError.set('APIからコマンド一覧を取得できませんでした。サンプル定義を表示しています。');
+        } else {
+            commands.set(remote);
+        }
+    } catch (error) {
+        console.warn('Failed to load commands, falling back to static definitions.', error);
+        commands.set(fallbackCommands);
+        commandsError.set('APIに接続できないため、サンプルのコマンド一覧を表示しています。');
+    } finally {
+        commandsLoading.set(false);
+    }
+}
+
+export async function launchJob(commandId: string, params: Record<string, unknown>): Promise<void> {
+    launchingJob.set(true);
+    jobError.set(null);
+    try {
+        const job = await createJob({ command_id: commandId, params });
+        registerOrUpdateJob(job);
+        await fetchLogs(job.id);
+        attachLogStream(job.id);
+    } catch (error) {
+        console.warn('Failed to launch job via API, falling back to mock execution.', error);
+        jobError.set('APIに接続できないため、モックジョブを開始しました。');
+        const job = createMockJob(commandId, params);
+        registerOrUpdateJob(job);
+        startMockLifecycle(job);
+    } finally {
+        launchingJob.set(false);
+    }
+}
+
+export async function refreshJob(jobId: string): Promise<void> {
+    try {
+        const job = await getJob(jobId);
+        registerOrUpdateJob(job);
+        await fetchLogs(jobId);
+    } catch (error) {
+        console.warn('Failed to refresh job from API.', error);
+    }
+}
+
+export async function selectJob(jobId: string | null): Promise<void> {
+    selectedJobId.set(jobId);
+    if (!jobId) {
+        return;
+    }
+
+    await fetchLogs(jobId);
+    const job = get(jobs).find((item) => item.id === jobId);
+    if (job && (job.status === 'pending' || job.status === 'running')) {
+        attachLogStream(jobId);
+    }
+}
+
+export function clearJobMessage(): void {
+    jobError.set(null);
+}
+
+export const jobStores = {
+    commands,
+    commandsLoading,
+    commandsError,
+    jobs,
+    jobLogs,
+    selectedJobId,
+    launchingJob,
+    jobError
+};
+
+function registerOrUpdateJob(job: JobSummary): void {
+    jobs.update((current) => {
+        const existingIndex = current.findIndex((item) => item.id === job.id);
+        const updated = existingIndex >= 0 ? [...current] : [job, ...current];
+        if (existingIndex >= 0) {
+            updated[existingIndex] = { ...updated[existingIndex], ...job };
+        } else {
+            selectedJobId.set(job.id);
+        }
+        return updated.sort((a, b) => {
+            const aTs = new Date(a.created_at ?? a.started_at ?? 0).getTime();
+            const bTs = new Date(b.created_at ?? b.started_at ?? 0).getTime();
+            return bTs - aTs;
+        });
+    });
+}
+
+async function fetchLogs(jobId: string): Promise<void> {
+    try {
+        const logs = await getJobLogs(jobId, 400);
+        setLogs(jobId, logs);
+    } catch (error) {
+        if (!mockJobTimers.has(jobId) && !mockLogIntervals.has(jobId)) {
+            console.debug('Failed to fetch logs for job', jobId, error);
+        }
+    }
+}
+
+function setLogs(jobId: string, logs: LogEvent[]): void {
+    jobLogs.update((current) => ({
+        ...current,
+        [jobId]: logs.slice(-400)
+    }));
+}
+
+function appendLog(jobId: string, events: LogEvent | LogEvent[]): void {
+    const newEvents = Array.isArray(events) ? events : [events];
+    jobLogs.update((current) => {
+        const existing = current[jobId] ?? [];
+        const merged = [...existing, ...newEvents];
+        return {
+            ...current,
+            [jobId]: merged.slice(-400)
+        };
+    });
+}
+
+function attachLogStream(jobId: string): void {
+    if (logStreams.has(jobId)) {
+        return;
+    }
+
+    try {
+        const socket = connectJobStream(jobId);
+        socket.addEventListener('message', (event) => {
+            try {
+                const data = JSON.parse(event.data) as LogEvent;
+                appendLog(jobId, { ...data, job_id: jobId });
+            } catch (parseError) {
+                console.warn('Failed to parse log event', parseError);
+            }
+        });
+        socket.addEventListener('close', () => {
+            logStreams.delete(jobId);
+        });
+        socket.addEventListener('error', (event) => {
+            console.warn('Log stream error', event);
+            logStreams.delete(jobId);
+            startMockLogStream(jobId);
+        });
+        logStreams.set(jobId, socket);
+    } catch (error) {
+        console.warn('Failed to open WebSocket log stream, using mock stream instead.', error);
+        startMockLogStream(jobId);
+    }
+}
+
+function closeLogStream(jobId: string): void {
+    const socket = logStreams.get(jobId);
+    if (socket) {
+        socket.close();
+        logStreams.delete(jobId);
+    }
+    closeMockLogInterval(jobId);
+}
+
+function startMockLogStream(jobId: string): void {
+    if (mockLogIntervals.has(jobId)) {
+        return;
+    }
+    const stop = createMockLogTicker(jobId);
+    mockLogIntervals.set(jobId, stop);
+}
+
+function createMockJob(commandId: string, params: Record<string, unknown>): JobSummary {
+    const now = new Date().toISOString();
+    return {
+        id: `mock-${Math.random().toString(36).slice(2, 10)}`,
+        command_id: commandId,
+        status: 'running',
+        params,
+        created_at: now,
+        started_at: now,
+        artifacts: []
+    };
+}
+
+function startMockLifecycle(job: JobSummary): void {
+    const jobId = job.id;
+    const startTs = Date.now();
+    const willFail = Math.random() < 0.12;
+
+    const timers: number[] = [];
+    const clearTimers = () => {
+        timers.forEach((timer) => window.clearTimeout(timer));
+        mockJobTimers.delete(jobId);
+    };
+
+    mockJobTimers.set(jobId, clearTimers);
+
+    appendLog(jobId, {
+        job_id: jobId,
+        level: 'info',
+        ts: new Date(startTs).toISOString(),
+        line: `${job.command_id} を開始しました。`
+    });
+
+    timers.push(
+        window.setTimeout(() => {
+            appendLog(jobId, {
+                job_id: jobId,
+                level: 'info',
+                ts: new Date().toISOString(),
+                line: '依存関係とリソースを初期化しています...'
+            });
+        }, 600)
+    );
+
+    timers.push(
+        window.setTimeout(() => {
+            appendLog(jobId, {
+                job_id: jobId,
+                level: 'info',
+                ts: new Date().toISOString(),
+                line: 'CrewAIフローを実行中...'
+            });
+        }, 1400)
+    );
+
+    timers.push(
+        window.setTimeout(() => {
+            appendLog(jobId, {
+                job_id: jobId,
+                level: willFail ? 'error' : 'info',
+                ts: new Date().toISOString(),
+                line: willFail
+                    ? '品質チェックでエラーが発生しました。ワークフローを中断します。'
+                    : '動画生成が完了しました。メタデータを整形しています...'
+            });
+        }, 2600)
+    );
+
+    timers.push(
+        window.setTimeout(() => {
+            const status: JobStatus = willFail ? 'failed' : 'succeeded';
+            updateJob(jobId, {
+                status,
+                finished_at: new Date().toISOString(),
+                message: willFail ? '品質検証でエラーが発生しました。' : 'ジョブが正常に完了しました。'
+            });
+            appendLog(jobId, {
+                job_id: jobId,
+                level: willFail ? 'error' : 'info',
+                ts: new Date().toISOString(),
+                line: willFail ? 'ジョブは失敗として終了しました。' : '成果物がアーカイブに保存されました。'
+            });
+            if (!willFail) {
+                appendLog(jobId, {
+                    job_id: jobId,
+                    level: 'info',
+                    ts: new Date().toISOString(),
+                    line: 'YouTubeメタデータを出力しました。'
+                });
+            }
+            closeLogStream(jobId);
+            clearTimers();
+        }, 4200)
+    );
+}
+
+function updateJob(jobId: string, patch: Partial<JobSummary>): void {
+    jobs.update((current) =>
+        current.map((item) => (item.id === jobId ? { ...item, ...patch } : item))
+    );
+}
+
+function createMockLogTicker(jobId: string): () => void {
+    let counter = 0;
+    const interval = window.setInterval(() => {
+        counter += 1;
+        appendLog(jobId, {
+            job_id: jobId,
+            level: 'info',
+            ts: new Date().toISOString(),
+            line: `ログストリームを監視中... (${counter})`
+        });
+    }, 1500);
+
+    return () => {
+        window.clearInterval(interval);
+        mockLogIntervals.delete(jobId);
+    };
+}
+
+function closeMockLogInterval(jobId: string): void {
+    const stop = mockLogIntervals.get(jobId);
+    if (stop) {
+        stop();
+        mockLogIntervals.delete(jobId);
+    }
+}

--- a/tauri-app/src/lib/types.ts
+++ b/tauri-app/src/lib/types.ts
@@ -1,0 +1,48 @@
+export type CommandParameterSchema = {
+    type: string;
+    title?: string;
+    description?: string;
+    enum?: string[];
+    default?: unknown;
+    properties?: Record<string, CommandParameterSchema & { required?: boolean }>;
+    items?: CommandParameterSchema;
+    required?: string[];
+};
+
+export interface CommandDefinition {
+    id: string;
+    label: string;
+    description?: string;
+    runner?: string;
+    params_schema?: CommandParameterSchema;
+}
+
+export type JobStatus = 'pending' | 'running' | 'succeeded' | 'failed' | 'cancelled';
+
+export interface JobArtifact {
+    name: string;
+    path: string;
+    type?: string;
+}
+
+export interface JobSummary {
+    id: string;
+    command_id: string;
+    status: JobStatus;
+    params?: Record<string, unknown>;
+    created_at?: string;
+    started_at?: string | null;
+    finished_at?: string | null;
+    artifacts?: JobArtifact[];
+    message?: string;
+}
+
+export type LogLevel = 'debug' | 'info' | 'warning' | 'error' | 'critical';
+
+export interface LogEvent {
+    job_id: string;
+    line: string;
+    level: LogLevel;
+    ts?: string;
+    source?: string;
+}

--- a/tauri-app/src/routes/+page.svelte
+++ b/tauri-app/src/routes/+page.svelte
@@ -1,2 +1,221 @@
-<h1>Welcome to SvelteKit</h1>
-<p>Visit <a href="https://svelte.dev/docs/kit">svelte.dev/docs/kit</a> to read the documentation</p>
+<script lang="ts">
+    import { onMount } from 'svelte';
+    import JobLauncher from '$lib/components/JobLauncher.svelte';
+    import JobMonitor from '$lib/components/JobMonitor.svelte';
+    import type { CommandDefinition } from '$lib/types';
+    import { jobStores, launchJob, loadCommands, selectJob, clearJobMessage } from '$lib/stores/jobStore';
+
+    const { commands, commandsLoading, commandsError, jobs, jobLogs, selectedJobId, launchingJob, jobError } = jobStores;
+
+    onMount(() => {
+        loadCommands();
+    });
+
+    $: commandList = $commands;
+    $: commandLookup = Object.fromEntries(commandList.map((command) => [command.id, command])) as Record<string, CommandDefinition>;
+    $: activeJobId = $selectedJobId;
+    $: activeLogs = activeJobId ? $jobLogs[activeJobId] ?? [] : [];
+
+    async function handleLaunch(event: CustomEvent<{ commandId: string; params: Record<string, unknown> }>) {
+        await launchJob(event.detail.commandId, event.detail.params);
+    }
+
+    function handleRefresh(): void {
+        loadCommands();
+    }
+
+    async function handleSelect(event: CustomEvent<{ jobId: string }>): Promise<void> {
+        await selectJob(event.detail.jobId);
+    }
+
+    $: bannerMessage = $jobError;
+
+    function statusIndicatorClass(loading: boolean, error: string | null): string {
+        if (error) return 'page__status-indicator page__status-indicator--error';
+        if (loading) return 'page__status-indicator page__status-indicator--loading';
+        return 'page__status-indicator';
+    }
+</script>
+
+<svelte:head>
+    <title>Crew Console</title>
+</svelte:head>
+
+<div class="page">
+    <header class="page__header">
+        <div>
+            <p class="page__eyebrow">CrewAI Workflow Control</p>
+            <h1>2510 YouTuber 制御パネル</h1>
+            <p class="page__lead">
+                デイリー自動生成ワークフローや検証コマンドを安全に実行し、ジョブ状況とログを一元監視します。
+            </p>
+        </div>
+        <div class="page__status">
+            <span class={statusIndicatorClass($commandsLoading, $commandsError)}>コマンド: {$commandsLoading ? '取得中…' : `${commandList.length}件`}</span>
+            {#if bannerMessage}
+                <button type="button" class="page__dismiss" on:click={clearJobMessage}>通知を閉じる</button>
+            {/if}
+        </div>
+    </header>
+
+    {#if bannerMessage}
+        <div class="page__banner">
+            <p>{bannerMessage}</p>
+        </div>
+    {/if}
+
+    {#if $commandsError && !bannerMessage}
+        <div class="page__warning">
+            <p>{$commandsError}</p>
+        </div>
+    {/if}
+
+    <main class="page__grid">
+        <JobLauncher
+            commands={commandList}
+            loading={$commandsLoading}
+            launching={$launchingJob}
+            error={$commandsError}
+            on:launch={handleLaunch}
+            on:refresh={handleRefresh}
+        />
+        <JobMonitor
+            jobs={$jobs}
+            selectedJobId={activeJobId}
+            logs={activeLogs}
+            commands={commandLookup}
+            on:select={handleSelect}
+        />
+    </main>
+</div>
+
+<style>
+    :global(body) {
+        margin: 0;
+        font-family: 'Inter', 'Noto Sans JP', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+        background: radial-gradient(circle at top, rgba(30, 64, 175, 0.35), rgba(15, 23, 42, 0.95));
+        color: #e2e8f0;
+        min-height: 100vh;
+    }
+
+    .page {
+        max-width: 1180px;
+        margin: 0 auto;
+        padding: 2.5rem 2rem 3rem;
+        display: flex;
+        flex-direction: column;
+        gap: 2rem;
+    }
+
+    .page__header {
+        display: flex;
+        justify-content: space-between;
+        gap: 2rem;
+        align-items: flex-start;
+    }
+
+    .page__eyebrow {
+        margin: 0;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        font-size: 0.75rem;
+        color: rgba(148, 163, 184, 0.75);
+    }
+
+    .page__header h1 {
+        margin: 0.35rem 0 0;
+        font-size: 2rem;
+    }
+
+    .page__lead {
+        margin: 0.75rem 0 0;
+        max-width: 46ch;
+        color: rgba(226, 232, 240, 0.8);
+        line-height: 1.6;
+    }
+
+    .page__status {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+        align-items: flex-end;
+    }
+
+    .page__status-indicator {
+        padding: 0.5rem 0.85rem;
+        border-radius: 9999px;
+        border: 1px solid rgba(148, 163, 184, 0.25);
+        background: rgba(15, 23, 42, 0.65);
+        font-size: 0.85rem;
+    }
+
+    .page__status-indicator--loading {
+        border-color: rgba(56, 189, 248, 0.35);
+        color: #38bdf8;
+    }
+
+    .page__status-indicator--error {
+        border-color: rgba(248, 113, 113, 0.45);
+        color: #f87171;
+    }
+
+    .page__dismiss {
+        border: none;
+        background: transparent;
+        color: rgba(226, 232, 240, 0.8);
+        font-size: 0.8rem;
+        cursor: pointer;
+        text-decoration: underline;
+    }
+
+    .page__banner,
+    .page__warning {
+        padding: 0.85rem 1rem;
+        border-radius: 14px;
+        border: 1px solid;
+        font-size: 0.9rem;
+    }
+
+    .page__banner {
+        border-color: rgba(56, 189, 248, 0.45);
+        background: rgba(56, 189, 248, 0.12);
+        color: #38bdf8;
+    }
+
+    .page__warning {
+        border-color: rgba(251, 191, 36, 0.45);
+        background: rgba(251, 191, 36, 0.12);
+        color: #fbbf24;
+    }
+
+    .page__grid {
+        display: grid;
+        grid-template-columns: 360px 1fr;
+        gap: 1.75rem;
+        align-items: start;
+    }
+
+    @media (max-width: 1080px) {
+        .page__grid {
+            grid-template-columns: 1fr;
+        }
+
+        .page__status {
+            align-items: flex-start;
+        }
+    }
+
+    @media (max-width: 640px) {
+        .page {
+            padding: 1.75rem 1.25rem 2.5rem;
+        }
+
+        .page__header {
+            flex-direction: column;
+        }
+
+        .page__lead {
+            max-width: 100%;
+        }
+    }
+</style>


### PR DESCRIPTION
## Summary
- introduce API client, types, and state stores to drive the Tauri GUI job controls with mocked fallbacks
- create JobLauncher and JobMonitor components and replace the landing page with the new dashboard layout
- ship a branded favicon and adjust ignore rules so the new Svelte lib assets are tracked

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_e_68e23d18e2d48325b01245f8dfc0fc79