### PR TITLE
fix: resolve ffmpeg binary during startup configuration

### DIFF
--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -355,6 +355,13 @@ class AppSettings(BaseModel):
                 imageio_ffmpeg = importlib.import_module(module_name)
                 config["ffmpeg_path"] = imageio_ffmpeg.get_ffmpeg_exe()
 
+        from app.services.media.ffmpeg_support import FFmpegConfigurationError, ensure_ffmpeg_tooling
+
+        try:
+            config["ffmpeg_path"] = ensure_ffmpeg_tooling(config.get("ffmpeg_path"))
+        except (FileNotFoundError, FFmpegConfigurationError) as exc:
+            raise RuntimeError(f"Failed to validate FFmpeg tooling: {exc}") from exc
+
         enable_stock_env = os.getenv("ENABLE_STOCK_FOOTAGE")
         if enable_stock_env is not None:
             config["enable_stock_footage"] = enable_stock_env.strip().lower() in {"1", "true", "yes", "on"}

--- a/app/services/media/__init__.py
+++ b/app/services/media/__init__.py
@@ -1,8 +1,7 @@
 """Media services for video generation and enhancement."""
 
 from .broll_generator import BRollGenerator
-from .ffmpeg_support import ensure_ffmpeg_tooling, FFmpegConfigurationError
-from .qa_pipeline import MediaQAError, MediaQAPipeline
+from .ffmpeg_support import FFmpegConfigurationError, ensure_ffmpeg_tooling
 from .stock_footage_manager import StockFootageManager
 from .visual_matcher import VisualMatcher
 
@@ -10,8 +9,6 @@ __all__ = [
     "StockFootageManager",
     "VisualMatcher",
     "BRollGenerator",
-    "MediaQAPipeline",
-    "MediaQAError",
     "ensure_ffmpeg_tooling",
     "FFmpegConfigurationError",
 ]

--- a/app/video.py
+++ b/app/video.py
@@ -806,8 +806,11 @@ class VideoGenerator:
 
     def _run_ffmpeg(self, stream, *, description: str) -> None:
         """Execute an ffmpeg stream and emit detailed diagnostics on failure."""
+
+        cmd = self.ffmpeg_path or "ffmpeg"
+
         try:
-            ffmpeg.run(stream, capture_stdout=True, capture_stderr=True)
+            ffmpeg.run(stream, cmd=cmd, capture_stdout=True, capture_stderr=True)
         except ffmpeg.Error as error:
             stdout = self._decode_ffmpeg_output(error.stdout)
             stderr = self._decode_ffmpeg_output(error.stderr)
@@ -818,11 +821,11 @@ class VideoGenerator:
             if stderr:
                 logger.error("ffmpeg %s stderr:%s%s", description, os.linesep, stderr)
             else:
-                logger.error("ffmpeg %s failed without stderr output: %s", description, error)
+                logger.error("ffmpeg %s failed without stderr output using %s: %s", description, cmd, error)
 
             raise
         except Exception:
-            logger.exception("Unexpected ffmpeg failure while %s", description)
+            logger.exception("Unexpected ffmpeg failure while %s using %s", description, cmd)
             raise
 
     def _generate_fallback_video(self, audio_path: str, subtitle_path: str, title: str) -> str:

--- a/app/workflow/steps.py
+++ b/app/workflow/steps.py
@@ -20,7 +20,7 @@ from app.prompts import (
 )
 from app.search_news import collect_news
 from app.services.file_archival import FileArchivalManager
-from app.services.media import MediaQAPipeline
+from app.services.media.qa_pipeline import MediaQAPipeline
 from app.services.script import ScriptFormatError, ensure_dialogue_structure
 from app.services.script.validator import Script
 from app.services.video_review import get_video_review_service

--- a/docs/investigations/2025-10-05-workflow-regression.md
+++ b/docs/investigations/2025-10-05-workflow-regression.md
@@ -1,0 +1,37 @@
+# 2025-10-05 Workflow Regression Investigation
+
+## Incident summary
+- **Symptom:** The CrewAI workflow began failing during the `video_generation` step at 14:04 JST, emitting repeated `ffmpeg` errors for both the primary render and the fallback video path.
+- **Last known good:** Runs completed successfully at 12:58 JST on the same day.
+- **Impact:** End-to-end automation halted because the fallback renderer also crashed, leaving no deliverable video artifact.
+
+## Commit timeline between 12:58 JST and 14:04 JST
+The window between the healthy and failing executions contains a dense batch of merges. The excerpt below highlights the most relevant entries:
+
+| Commit | Time (JST) | Notes |
+| --- | --- | --- |
+| `4e0fc35` → `5bd8dc0` | 13:07–13:11 | Prompt helper refactors, no runtime impact. |
+| `e286714` | 13:13 | Prompt default centralisation (config/docs only). |
+| `9f676e4` | 13:46 | Adds subtitle-burning logic to the fallback renderer and new tests. |
+| `c5bb00c` | 13:54 | Major refactor folding B-roll pre-generation into `VideoGenerator` and `GenerateVideoStep`. |
+| `afc63e6`, `f57a016` | 13:56 | Merge wrappers for the above feature work. |
+
+`git log` confirms that `app/video.py` only changed in this window via `9f676e4` and the large `c5bb00c` refactor, while the surrounding commits touch prompts, docs, or metadata plumbing.【a35ea0†L1-L18】【f6d67f†L1-L5】
+
+## Findings
+1. **Environment drifted away from a system ffmpeg binary.**
+   - `which ffmpeg` now resolves to nothing inside the runtime container, meaning `ffmpeg-python` cannot rely on the bare `ffmpeg` executable name.【fe1b4b†L1-L2】
+   - Executing the compiled render command verbatim demonstrates the failure: the shell reports `command not found: ffmpeg` when the binary name is not fully qualified.【4a1032†L5-L10】【b27770†L1-L5】
+2. **`VideoGenerator` already resolves a working binary via `ensure_ffmpeg_tooling`.**
+   - Construction of the generator hydrates `self.ffmpeg_path` with the validated imageio shim, and all renders flow through `_run_ffmpeg` after the follow-up fix.【a2658a†L160-L190】【532e58†L807-L829】
+3. **Root cause is not limited to B-roll changes.**
+   - Although `c5bb00c` reshaped B-roll orchestration, the decisive break was the environment’s missing `ffmpeg` shim on `$PATH`; prior runs succeeded because the binary happened to be globally available. Once it disappeared, every `ffmpeg.run(...)` call that relied on the default command string began failing, including the fallback renderer introduced in `9f676e4`.
+
+## Resolution status
+- The latest patch (`cfce931`) routes every `ffmpeg.run` call through `_run_ffmpeg`, which now injects `self.ffmpeg_path` so the validated binary is always executed, even when `$PATH` lacks `ffmpeg`.【532e58†L807-L829】
+- No additional regressions surfaced in adjacent modules during the investigation window; non-media commits in the log affect prompts, docs, or metadata tracking only.【a35ea0†L1-L18】
+
+## Recommended follow-ups
+1. Add a lightweight startup check (e.g., `ffmpeg -version` through `ensure_ffmpeg_tooling`) to fail fast when configuration drifts.
+2. Keep `VideoGenerator` smoke tests around the fallback renderer so subtitle changes (like `9f676e4`) stay covered.
+3. Document the dependency on `imageio-ffmpeg` in the deployment guide to avoid future PATH regressions.

--- a/tests/unit/test_settings_ffmpeg.py
+++ b/tests/unit/test_settings_ffmpeg.py
@@ -1,0 +1,31 @@
+import importlib
+
+import pytest
+
+
+@pytest.mark.unit
+def test_app_settings_load_resolves_ffmpeg(monkeypatch, tmp_path):
+    fake_binary = tmp_path / "ffmpeg"
+    fake_binary.write_text("#!/bin/sh\nexit 0\n")
+    fake_binary.chmod(0o755)
+
+    settings_module = importlib.import_module("app.config.settings")
+    ffmpeg_support = importlib.import_module("app.services.media.ffmpeg_support")
+
+    def fake_which(candidate):
+        return str(fake_binary) if candidate == "ffmpeg" else None
+
+    monkeypatch.setattr(settings_module.shutil, "which", fake_which)
+
+    captured = {}
+
+    def fake_ensure(path=None):
+        captured["path"] = path
+        return "/opt/tools/resolved-ffmpeg"
+
+    monkeypatch.setattr(ffmpeg_support, "ensure_ffmpeg_tooling", fake_ensure)
+
+    loaded = settings_module.AppSettings.load()
+
+    assert captured["path"] == "ffmpeg"
+    assert loaded.ffmpeg_path == "/opt/tools/resolved-ffmpeg"


### PR DESCRIPTION
## Summary
- validate and resolve the ffmpeg binary when AppSettings loads so all services share the verified path
- remove the MediaQAPipeline re-export to break the config import cycle and update the workflow import
- add a unit test ensuring AppSettings delegates to ensure_ffmpeg_tooling for ffmpeg resolution

## Testing
- pytest tests/unit/test_settings_ffmpeg.py -vv
- pytest tests/unit/test_utils_ffmpeg_support.py -vv
- pytest tests/unit/test_video_review.py -vv

------
https://chatgpt.com/codex/tasks/task_e_68e23f7e1bd483258c36242d793e60b8