### PR TITLE
fix: validate ffmpeg tooling during startup

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -24,6 +24,7 @@ _LOG_SESSION = setup_logging(log_level=log_level)
 
 from .api_rotation import initialize_api_infrastructure
 from .config import cfg
+from .services.media import FFmpegConfigurationError, ensure_ffmpeg_tooling
 from .discord import discord_notifier
 from .metadata_storage import metadata_storage
 from .models.workflow import WorkflowResult
@@ -51,6 +52,13 @@ logger = logging.getLogger(__name__)
 # Initialize API infrastructure once at module import
 initialize_api_infrastructure()
 logger.info("API infrastructure initialized at startup")
+
+try:
+    _STARTUP_FFMPEG_PATH = ensure_ffmpeg_tooling(cfg.ffmpeg_path)
+except (FileNotFoundError, FFmpegConfigurationError) as exc:  # pragma: no cover - defensive startup guard
+    raise RuntimeError(f"FFmpeg validation failed during startup: {exc}") from exc
+else:
+    logger.info("FFmpeg binary validated at startup: %s", _STARTUP_FFMPEG_PATH)
 
 
 class YouTubeWorkflow:

--- a/tests/unit/test_main_startup.py
+++ b/tests/unit/test_main_startup.py
@@ -1,0 +1,31 @@
+import importlib
+import sys
+
+def test_main_validates_ffmpeg_on_import(monkeypatch):
+    """app.main should validate FFmpeg availability during module import."""
+
+    # Ensure a clean import of app.main
+    sys.modules.pop("app.main", None)
+
+    # Stub API infrastructure initialization to avoid external side effects
+    import app.api_rotation as api_rotation
+
+    monkeypatch.setattr(api_rotation, "initialize_api_infrastructure", lambda: None)
+
+    # Patch FFmpeg tooling validation to observe the startup check
+    import app.services.media as media_pkg
+    import app.services.media.ffmpeg_support as ffmpeg_support
+
+    def fake_ensure(path):
+        return "stub-ffmpeg"
+
+    monkeypatch.setattr(ffmpeg_support, "ensure_ffmpeg_tooling", fake_ensure)
+    monkeypatch.setattr(media_pkg, "ensure_ffmpeg_tooling", fake_ensure)
+
+    module = importlib.import_module("app.main")
+
+    try:
+        assert getattr(module, "_STARTUP_FFMPEG_PATH") == "stub-ffmpeg"
+    finally:
+        # Clean up to avoid impacting other tests
+        sys.modules.pop("app.main", None)


### PR DESCRIPTION
## Summary
- validate ffmpeg availability when app.main loads and surface a clear startup error if the binary is missing
- log the resolved ffmpeg path so workflow logs capture the verified tooling location
- cover the startup guard with a unit test that stubs infrastructure initialization

## Testing
- pytest tests/unit/test_main_startup.py

------
https://chatgpt.com/codex/tasks/task_e_68e24c55e034832587f38f0e55a20218