### PR TITLE
fix: validate structured scripts as yaml

### DIFF
--- a/app/crew/flows.py
+++ b/app/crew/flows.py
@@ -39,6 +39,7 @@ class WOWScriptFlow:
             "success": True,
             "final_script": result.script,
             "metadata": metadata,
+            "structured_script_yaml": result.structured_yaml,
         }
 
 

--- a/tests/unit/services/script/test_generator_yaml.py
+++ b/tests/unit/services/script/test_generator_yaml.py
@@ -1,0 +1,22 @@
+from unittest.mock import MagicMock
+
+import yaml
+
+from app.services.script.generator import StructuredScriptGenerator
+from app.services.script.validator import DialogueEntry, Script
+
+
+def test_dump_script_to_yaml_round_trip():
+    generator = StructuredScriptGenerator(client=MagicMock(), allowed_speakers=("テストA", "テストB"))
+    script = Script(
+        title="テスト台本",
+        dialogues=[
+            DialogueEntry(speaker="テストA", line="こんにちは"),
+            DialogueEntry(speaker="テストB", line="解説を始めましょう"),
+        ],
+    )
+
+    yaml_blob = generator._dump_script_to_yaml(script)
+
+    loaded = yaml.safe_load(yaml_blob)
+    assert loaded == script.model_dump(mode="json")


### PR DESCRIPTION
## Summary
- serialize structured scripts to YAML in the generator and validate them immediately
- surface the validated YAML through the Crew flow and workflow steps for downstream consumers
- add a unit test that checks the YAML round-trip helper

## Testing
- pytest tests/unit/services/script/test_generator_yaml.py

------
https://chatgpt.com/codex/tasks/task_e_68e3950171d08325b40ba5d3868edeb6