### PR TITLE
fix: harden structured script json parsing

### DIFF
--- a/app/services/script/generator.py
+++ b/app/services/script/generator.py
@@ -217,18 +217,30 @@ class StructuredScriptGenerator:
         stripped = text.strip()
         if not stripped:
             return None
-        if stripped.startswith('{'):
-            if StructuredScriptGenerator._is_balanced_json(stripped):
-                return stripped
-        start = stripped.find('{')
-        if start == -1:
-            return None
-        slice_text = stripped[start:]
-        end_index = StructuredScriptGenerator._find_matching_brace(slice_text)
-        if end_index is None:
-            return None
-        candidate = slice_text[:end_index + 1]
-        return candidate if StructuredScriptGenerator._is_balanced_json(candidate) else None
+        if stripped.startswith('{') and StructuredScriptGenerator._is_balanced_json(stripped):
+            return stripped
+
+        search_start = 0
+        while True:
+            start = stripped.find('{', search_start)
+            if start == -1:
+                return None
+
+            slice_text = stripped[start:]
+            end_index = StructuredScriptGenerator._find_matching_brace(slice_text)
+            if end_index is None:
+                search_start = start + 1
+                if search_start >= len(stripped):
+                    return None
+                continue
+
+            candidate = slice_text[:end_index + 1]
+            if StructuredScriptGenerator._is_balanced_json(candidate):
+                return candidate
+
+            search_start = start + 1
+            if search_start >= len(stripped):
+                return None
 
     @staticmethod
     def _extract_message_text(response: Dict[str, Any]) -> str:

--- a/tests/unit/services/script/test_generator_parsing.py
+++ b/tests/unit/services/script/test_generator_parsing.py
@@ -1,0 +1,23 @@
+"""Tests for extracting structured JSON from LLM responses."""
+
+from app.services.script.generator import StructuredScriptGenerator
+
+
+def test_extract_json_block_skips_non_json_braces():
+    noisy_text = (
+        "補足:{説明}\n"
+        "\n"
+        '{"title": "Valid Script", "dialogues": []}'
+    )
+
+    extracted = StructuredScriptGenerator._extract_json_block(noisy_text)
+
+    assert extracted == '{"title": "Valid Script", "dialogues": []}'
+
+
+def test_extract_json_block_handles_markdown_code_blocks():
+    markdown = "```json\n{\n  \"title\": \"Test\",\n  \"dialogues\": []\n}\n```\n補足"
+
+    extracted = StructuredScriptGenerator._extract_json_block(markdown)
+
+    assert extracted == '{\n  "title": "Test",\n  "dialogues": []\n}'


### PR DESCRIPTION
## Summary
- make the structured script generator search for the first valid JSON object even when earlier braces appear in the LLM response
- add unit coverage for noisy brace content and markdown code blocks to guard future regressions

## Testing
- pytest tests/unit -q

------
https://chatgpt.com/codex/tasks/task_e_68e3b0952d1c83259b5e166106867d52