### PR TITLE
fix: prune stale workflow artifacts on retries

### DIFF
--- a/app/workflow/base.py
+++ b/app/workflow/base.py
@@ -5,7 +5,7 @@ Implements Strategy pattern for separating workflow logic into testable, composa
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Iterable, List, Optional
 
 
 @dataclass
@@ -43,6 +43,20 @@ class WorkflowContext:
     def add_files(self, files: List[str]) -> None:
         """Add generated files to tracking."""
         self.generated_files.extend(files)
+
+    def remove_files(self, files: Iterable[str]) -> None:
+        """Remove generated files from tracking when they are deleted."""
+
+        if not files:
+            return
+
+        files_to_remove = set(filter(None, files))
+        if not files_to_remove:
+            return
+
+        self.generated_files = [
+            path for path in self.generated_files if path not in files_to_remove
+        ]
 
 
 class WorkflowStep(ABC):

--- a/app/workflow_runtime.py
+++ b/app/workflow_runtime.py
@@ -1,0 +1,181 @@
+"""Runtime helpers for orchestrating the Crew-based workflow."""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from typing import Any, Dict, Iterable, List, Optional, Sequence
+
+from .workflow import WorkflowContext, WorkflowStep
+
+
+@dataclass
+class ScriptInsights:
+    """Container object for metrics extracted from the script generation step."""
+
+    wow_score: Optional[float] = None
+    surprise_points: Optional[int] = None
+    emotion_peaks: Optional[int] = None
+    visual_instructions: Optional[int] = None
+    retention_prediction: Optional[float] = None
+    japanese_purity: Optional[float] = None
+    hook_variant: Optional[str] = None
+    title_variants: List[str] = field(default_factory=list)
+    thumbnail_prompts: List[str] = field(default_factory=list)
+    emotion_curve: Optional[List[Dict[str, Any]]] = None
+    visual_calls_to_action: Optional[List[str]] = None
+    visual_b_roll_suggestions: Optional[List[str]] = None
+    emotion_highlights: Optional[List[str]] = None
+    visual_guidelines: Optional[List[str]] = None
+    visual_shot_list: Optional[List[str]] = None
+
+    @classmethod
+    def from_step(cls, script_step: Any) -> "ScriptInsights":
+        if not script_step or not hasattr(script_step, "data"):
+            return cls()
+
+        data = script_step.data or {}
+        metrics = data.get("script_metrics", {}) or {}
+
+        def _as_list(value: Any) -> List[str]:
+            if isinstance(value, list):
+                return [str(item) for item in value if item is not None]
+            if value:
+                return [str(value)]
+            return []
+
+        return cls(
+            wow_score=metrics.get("wow_score"),
+            surprise_points=metrics.get("surprise_points"),
+            emotion_peaks=metrics.get("emotion_peaks"),
+            visual_instructions=metrics.get("visual_instructions"),
+            retention_prediction=metrics.get("retention_prediction"),
+            japanese_purity=data.get("japanese_purity_score")
+            or metrics.get("japanese_purity"),
+            hook_variant=data.get("hook_variant"),
+            title_variants=_as_list(data.get("title_variants")),
+            thumbnail_prompts=_as_list(data.get("thumbnail_prompts")),
+            emotion_curve=metrics.get("emotion_curve")
+            if isinstance(metrics.get("emotion_curve"), list)
+            else None,
+            visual_calls_to_action=_as_list(metrics.get("visual_calls_to_action"))
+            or None,
+            visual_b_roll_suggestions=_as_list(metrics.get("visual_b_roll_suggestions"))
+            or None,
+            emotion_highlights=_as_list(metrics.get("emotion_highlights")) or None,
+            visual_guidelines=_as_list(data.get("visual_guidelines")) or None,
+            visual_shot_list=_as_list(data.get("visual_shot_list")) or None,
+        )
+
+
+class AttemptStatus(Enum):
+    """Possible outcomes for a single workflow attempt."""
+
+    SUCCESS = "success"
+    RETRY = "retry"
+    FAILURE = "failure"
+
+
+@dataclass
+class AttemptOutcome:
+    """High-level summary describing how an attempt finished."""
+
+    status: AttemptStatus
+    restart_index: Optional[int] = None
+    reason: Optional[str] = None
+    failure_step: Optional[str] = None
+    failure_result: Optional[Any] = None
+
+
+@dataclass
+class WorkflowRunState:
+    """State tracker for a single workflow execution attempt."""
+
+    run_id: str
+    mode: str
+    context: WorkflowContext
+    steps: Sequence[WorkflowStep]
+    retry_cleanup_map: Dict[str, Iterable[str]]
+    start_time: datetime = field(default_factory=datetime.now)
+    attempt: int = 0
+    start_index: int = 0
+    results: List[Optional[Any]] = field(init=False)
+    _step_files: List[List[str]] = field(init=False)
+    retry_requested: bool = False
+
+    def __post_init__(self) -> None:
+        self.results = [None] * len(self.steps)
+        self._step_files = [[] for _ in self.steps]
+
+    def start_attempt(self) -> None:
+        """Advance the attempt counter and reset retry flags."""
+
+        self.attempt += 1
+        self.retry_requested = False
+
+    def register_result(self, index: int, result: Any) -> None:
+        """Store the result for a step and capture any generated files."""
+
+        self.results[index] = result
+        files = getattr(result, "files_generated", None)
+        if files:
+            recorded_files = [file_path for file_path in files if file_path]
+            self._step_files[index] = recorded_files
+            if recorded_files:
+                self.context.add_files(recorded_files)
+        else:
+            self._step_files[index] = []
+
+    def request_retry(self, start_index: int) -> None:
+        """Prepare to rerun from a specific step on the next attempt."""
+
+        self.retry_requested = True
+        self.start_index = start_index
+        self._clear_state_from(start_index)
+
+    def _clear_state_from(self, start_index: int) -> None:
+        """Drop cached step outputs and context keys beyond the restart point."""
+
+        for idx in range(start_index, len(self.results)):
+            self.results[idx] = None
+            if self._step_files[idx]:
+                self._remove_step_files(idx)
+        for step in self.steps[start_index:]:
+            keys_to_remove = self.retry_cleanup_map.get(step.step_name, [])
+            for key in keys_to_remove:
+                if key in self.context.state:
+                    self.context.state.pop(key, None)
+
+    def _remove_step_files(self, index: int) -> None:
+        """Delete files produced by a step and forget them from the context."""
+
+        files_to_remove = self._step_files[index]
+        if not files_to_remove:
+            return
+
+        for path in files_to_remove:
+            if not path:
+                continue
+            try:
+                if os.path.exists(path):
+                    os.remove(path)
+            except OSError as exc:
+                logging.getLogger(__name__).warning(
+                    "Failed to remove stale artifact %s: %s", path, exc
+                )
+
+        self.context.remove_files(files_to_remove)
+        self._step_files[index] = []
+
+    def completed_results(self) -> List[Any]:
+        """Return all step results recorded so far."""
+
+        return [result for result in self.results if result is not None]
+
+    def execution_time_seconds(self) -> float:
+        """Compute the total runtime in seconds since the state was created."""
+
+        return (datetime.now() - self.start_time).total_seconds()

--- a/docs/GEMINI_END_TO_END_FLOW.md
+++ b/docs/GEMINI_END_TO_END_FLOW.md
@@ -1,0 +1,82 @@
+# GEMINI 活用フローの実践カタログ
+
+CrewAI ベースの台本生成パイプラインで Gemini を呼び出す前後の処理を、**工程・責務・制御ポイント・致命的失敗モード**の 4 軸で破壊的に再構成したドキュメントです。単なる手順列挙ではなく、**誰が・何を・どこまで自動化し・どこで止めるべきか**が即座に把握できることを目指しています。
+
+## 1. フェーズ別スイムレーンタイムライン
+
+| タイムライン | ビジネスオペレーション | オーケストレーション (`YouTubeWorkflow`) | Gemini 連携 (`StructuredScriptGenerator`) | メディア処理 / 発信 |
+| --- | --- | --- | --- | --- |
+| 0. 事前初期化 | - 公開予定日の確定<br>- API キー棚卸し | `initialize_api_infrastructure()` でキー回転プールを構成<br>`ensure_ffmpeg_tooling()` で FFmpeg を検証 | - | - |
+| 1. 素材収集 | `CollectNewsStep` がニュース API と Google Sheets を照合 | `WorkflowContext` にニュース群・制約・話者設定を保持 | - | - |
+| 2. 台本生成 | - | `GenerateScriptStep` が Gemini ルートを選択 (`cfg.use_crewai_script_generation`) | `StructuredScriptGenerator` がプロンプト整形→Gemini 呼び出し→応答検証 | - |
+| 3. メディア波及 | - | `WorkflowContext` に台本メタを格納し後続ステップを呼び出し | - | `SynthesizeAudioStep` 〜 `QualityAssuranceStep` が音声・字幕・動画・公開メタを生成 |
+| 4. 監査とロールバック | - | 失敗時に `RETRY_CLEANUP_MAP` を参照しクリーンアップ | `record_llm_interaction()` がリクエスト/レスポンスを永続化 | 公開停止/再実行の意思決定をオペレーションが実施 |
+
+> **判断ポイント**: フェーズ 2 完了直後に QA チェックを挟めるよう `WorkflowContext['script_quality']` を監視すると、Gemini 応答の破綻を後続工程に波及させずに遮断できる。
+
+## 2. 制御フロー詳細 (BPMN テキスト表現)
+
+| 番号 | イベント/タスク | 入力 | 制御 | 出力 | 中断条件 |
+| --- | --- | --- | --- | --- | --- |
+| G0 | API 基盤の起動 | `.env` / Secrets Manager | `APIKeyRotationManager.register_keys()` | 有効化されたキー回転プール | キー不在 → プロセス終了 |
+| G1 | メディア依存検証 | システム PATH | `ensure_ffmpeg_tooling()` | FFmpeg 動作保証 | 実行ファイル欠落 → 強制停止 |
+| G2 | ニュース収集 | ニュース API, Google Sheets | `CollectNewsStep.collect_news()` | 正規化されたニュース配列 | API 失敗 → リトライ 3 回後停止 |
+| G3 | コンテキスト構築 | G2 の出力 | `WorkflowContext.update()` | `news_items`, `constraints` | バリデーション失敗 → G2 へロールバック |
+| G4 | Gemini ルート選択 | 設定値 `cfg.use_crewai_script_generation` | 分岐: Gemini / ローカル LLM | 経路判定フラグ | False → ローカル台本で代替 |
+| G5 | プロンプト生成 | `news_items`, 話者設定 | `_build_prompt()` | JSON スキーマ付きプロンプト | フォーマット失敗 → 1 回再試行後 G4 へ戻る |
+| G6 | Gemini 呼び出し | G5 プロンプト, API キー | `LLMClient.completion(max_attempts=3)` | 生テキスト応答, レート制限情報 | 失敗 → キー回転 → 再試行 → G4 分岐 |
+| G7 | 応答パース | G6 応答 | `_parse_payload()` + `_ensure_min_dialogues()` | `ScriptGenerationResult` (YAML, メタ含む) | JSON 破損 → フォールバック台本 |
+| G8 | 台本品質ゲート | G7 出力 | `ensure_dialogue_structure()` | QA 通過済み台本 | 不合格 → G4 へ戻り再生成 |
+| G9 | メディア生成連鎖 | G8 出力 | `SynthesizeAudioStep`→`TranscribeAudioStep`→`GenerateVideoStep` など | 音声, 字幕, 動画, サムネ, メタ | ステップ失敗 → `RETRY_CLEANUP_MAP` で該当成果物削除 |
+| G10 | 監査ログ書き込み | G6 入出力, キー識別子 | `record_llm_interaction()` | 監査トレイル | ストレージ障害 → ローカル退避 (後述) |
+| G11 | 最終公開判断 | G9 成果物, QA レポート | オペレーションレビュー | 公開 / 保留 / 再実行の決定 | QA 不合格 → G4/G9 へ巻き戻し |
+
+## 3. 役割別 RACI マトリクス
+
+| フェーズ | CrewAI Orchestrator | Gemini SRE | メディア Ops | 法務/コンプラ |
+| --- | --- | --- | --- | --- |
+| 0. 事前初期化 | **R**: 初期化手順実行<br>**A**: 成功判定 | **C**: キープール充足確認 | **I** | **I** |
+| 1. 素材収集 | **R**: API 呼び出し | **I** | **C**: 収集ニュースのポリシー整合性 | **C**: 著作権チェック |
+| 2. 台本生成 | **R**: プロンプト構築と呼び出し<br>**A**: 応答品質判定 | **C**: レート制限監視 | **I** | **C**: 台本表現の規制適合性 |
+| 3. メディア波及 | **C** | **I** | **R/A**: 音声/動画生成と QA | **I** |
+| 4. 監査/ロールバック | **R**: `RETRY_CLEANUP_MAP` 運用 | **A**: キー失効対応計画 | **C** | **A**: 監査証跡保全 |
+
+## 4. データライフサイクルと保持ポリシー
+
+| フェーズ | 主なデータ | 保持先 | 保存期間 | 消去トリガー |
+| --- | --- | --- | --- | --- |
+| 0 | API キー, ローテーションメトリクス | Secrets Manager, ログ | 90 日 | キー失効 |
+| 1 | ニュース素材, プロンプト要件 | Firestore / `WorkflowContext` | 7 日 | 公開後のバッチ完了 |
+| 2 | Gemini 応答, YAML 台本, 品質メタ | ローカル一時ファイル, `data/` の内部ストレージ | 30 日 (再利用検証期間) | 次リリース後のクリーンアップジョブ |
+| 3 | 音声, 字幕, 動画, サムネイル | Google Drive, S3 | 365 日 | 著作権/契約更新 |
+| 4 | LLM 監査ログ, 失敗ログ | Firestore + ローカル冗長ログ | 365 日 | コンプラレビュー完了 |
+
+## 5. 障害復旧パスとガードレール
+
+| 失敗モード | 即時検出指標 | 自動復旧 | 手動介入 | SLA への影響 |
+| --- | --- | --- | --- | --- |
+| Gemini レート制限 (HTTP 429) | `LLMClient` のエラーカウンタ | キー回転 → バックオフ → 最大 3 回リトライ | SRE が API クォータ調整 | 20 分以内に復旧できなければ当日配信遅延 |
+| JSON 解析失敗 | `_parse_payload()` の例外 | フォールバック台本要求 | 編集チームが手動で台本修正 | QA 追加 30 分 |
+| FFmpeg 欠落 | 初期化時の `ensure_ffmpeg_tooling()` | - | DevOps がバイナリ配置 | 起動不可 → 配信停止 |
+| 音声合成失敗 | `SynthesizeAudioStep` のリトライ記録 | 3 回まで自動リトライ | ナレーターが緊急収録 | 2 時間以内の復旧を目標 |
+| 監査ログ永続化失敗 | Firestore 書き込み例外 | ローカル冗長ログ (`logs/pending_llm_audit.jsonl`) へ退避 | コンプラ担当が再投入ジョブを実行 | 監査証跡 24 時間以内に整合 |
+
+## 6. 現行フローの致命的な欠点 (アップデート)
+
+| 区分 | 欠点 | 発生条件 | 致命性の理由 | 応急対応 | 恒久対策 | 指標 |
+| --- | --- | --- | --- | --- | --- | --- |
+| キー管理 | `initialize_api_infrastructure()` が複数キー前提で、単一キー環境ではフェイルオーバーせず停止する | 新規導入時にキー本数が不足 | 429/失効で即全停止、当日配信が全滞 | `cfg.use_crewai_script_generation=False` でローカル LLM 経路を強制 | Secrets Manager に最小 3 本登録を CI で検証 | `rotation_pool_size` < 2 を Slack へ通知 |
+| 生成品質 | `_parse_payload()` がヒューリスティック補修後も `ensure_dialogue_structure()` をすり抜ける | Gemini 応答が部分 JSON になる | 誤台本が音声・動画工程へ波及しリソースを浪費 | フェールクローズ: 補修失敗時は即フォールバック台本を要求 | Gemini 応答スキーマを Strict Pydantic モデルに変更し `json_schema` を Gemini に渡す | QA で `dialogue_coverage` < 0.9 をブロック |
+| 監査ログ | `record_llm_interaction()` が永続化失敗時にリトライしない | Firestore/DB 障害 | コンプラ監査で証跡欠落が致命的瑕疵になる | ローカル冗長ログへ退避し、`audit_replay.py` で再投入 | Firestore 書き込みを非同期キュー化し ACK を監視 | `audit_queue_depth` > 100 を PagerDuty 通知 |
+
+## 7. 速習チェックリスト
+
+- [ ] `.env` と Secrets Manager の Gemini キーが **3 本以上**登録済みである。
+- [ ] `uv run python -m app.verify` を実行し、API/メディア依存性が揃っている。
+- [ ] Google Sheets の上書きプロンプトとニュース API が同期している。
+- [ ] `WorkflowContext['script_quality']` を可視化するダッシュボードがある。
+- [ ] Firestore 障害時に `logs/pending_llm_audit.jsonl` が 24 時間以内に空になる運用が定着している。
+
+---
+
+本カタログは、Gemini 経路の自動化と人間による監視を両立させるための**恒久的な意思決定基盤**として利用してください。初期化から監査までの各フェーズは独立した責務を持ち、致命的欠点のモニタリング指標と組み合わせることで、破壊的な改善サイクルを継続的に回せます。


### PR DESCRIPTION
## Summary
- track files generated by each workflow step and expose WorkflowContext.remove_files so retry cleanup can untrack them
- delete stale artifacts when QA requests a retry and warn if filesystem cleanup fails
- clear the generated file register after final cleanup to prevent leaking paths between attempts

## Testing
- pytest tests/unit -k workflow -q

------
https://chatgpt.com/codex/tasks/task_e_68e44f14f7fc83259668646b491ca446