### PR TITLE
fix: offload news collection IO

### DIFF
--- a/app/container.py
+++ b/app/container.py
@@ -133,7 +133,7 @@ class AppContainer:
         if self._workflow is None:
             from app.main import YouTubeWorkflow
 
-            self._workflow = YouTubeWorkflow()
+            self._workflow = YouTubeWorkflow(notifier=self.discord_notifier)
             logger.debug("YouTubeWorkflow created")
         return self._workflow
 

--- a/app/discord.py
+++ b/app/discord.py
@@ -1,141 +1,153 @@
-"""Discord通知モジュール
+"""Discord通知モジュール.
 
-システムの実行状況や結果をDiscordに通知します。
+Provides asynchronous notification helpers so workflow execution does not block
+when sending webhook messages.
 """
 
+from __future__ import annotations
+
+import asyncio
 import logging
 import time
 from datetime import datetime
-from typing import Any, Dict, Optional
+from typing import Any, Awaitable, Callable, Dict, Optional
 
 import httpx
 
 from app.config_prompts.settings import settings as cfg
+from app.notifications.interfaces import Notifier
 
 logger = logging.getLogger(__name__)
 
 
-class DiscordNotifier:
-    """Discord通知クラス"""
+class DiscordNotifier(Notifier):
+    """Discord webhook notifier supporting async + sync execution paths."""
 
-    def __init__(self):
-        self.webhook_url = cfg.discord_webhook_url
+    def __init__(
+        self,
+        webhook_url: Optional[str] = None,
+        *,
+        timeout: float = 10.0,
+        client_factory: Optional[Callable[[], httpx.AsyncClient]] = None,
+        run_sync: Optional[Callable[[Awaitable[bool]], bool]] = None,
+    ) -> None:
+        self.webhook_url = webhook_url if webhook_url is not None else cfg.discord_webhook_url
         self.enabled = bool(self.webhook_url)
+        self._timeout = timeout
+        self._client_factory = client_factory or self._default_client_factory
+        self._run_sync = run_sync or asyncio.run
 
         if not self.enabled:
             logger.warning("Discord webhook URL not configured, notifications disabled")
 
-    def notify(
-        self, message: str, level: str = "info", title: Optional[str] = None, fields: Optional[Dict[str, Any]] = None
+    def _default_client_factory(self) -> httpx.AsyncClient:
+        return httpx.AsyncClient(timeout=self._timeout)
+
+    def _run_blocking(self, coroutine: Awaitable[bool]) -> bool:
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            return self._run_sync(coroutine)
+        raise RuntimeError("notify_blocking cannot be used inside an active event loop")
+
+    async def notify(
+        self,
+        message: str,
+        *,
+        level: str = "info",
+        title: Optional[str] = None,
+        fields: Optional[Dict[str, Any]] = None,
     ) -> bool:
-        """基本的なDiscord通知
+        """Send a Discord notification asynchronously."""
 
-        Args:
-            message: 通知メッセージ
-            level: ログレベル (info/warning/error/success)
-            title: タイトル（省略時は自動設定）
-            fields: 追加フィールド
-
-        Returns:
-            送信成功時True
-
-        """
         if not self.enabled:
-            logger.info(f"[Discord disabled] {message}")
+            logger.info("[Discord disabled] %s", message)
             return False
+
+        level_config = {
+            "info": {"color": "#36a64f", "icon": "ℹ️"},
+            "success": {"color": "#36a64f", "icon": "✅"},
+            "warning": {"color": "#ff9500", "icon": "⚠️"},
+            "error": {"color": "#ff0000", "icon": "❌"},
+            "debug": {"color": "#808080", "icon": "🔧"},
+        }
+        config = level_config.get(level, level_config["info"])
+        icon = config["icon"]
+        color = config["color"]
+
+        embed_title = title or "YouTube Automation"
+        payload = {
+            "embeds": [
+                {
+                    "color": int(color.replace("#", ""), 16),
+                    "title": f"{icon} {embed_title}",
+                    "description": message,
+                    "footer": {"text": "YouTube Automation System"},
+                    "timestamp": datetime.fromtimestamp(time.time()).isoformat(),
+                }
+            ]
+        }
+
+        if fields:
+            payload["embeds"][0]["fields"] = [
+                {"name": key, "value": str(value), "inline": True}
+                for key, value in fields.items()
+            ]
 
         try:
-            # レベルに応じた色とアイコン
-            level_config = {
-                "info": {"color": "#36a64f", "icon": "ℹ️"},
-                "success": {"color": "#36a64f", "icon": "✅"},
-                "warning": {"color": "#ff9500", "icon": "⚠️"},
-                "error": {"color": "#ff0000", "icon": "❌"},
-                "debug": {"color": "#808080", "icon": "🔧"},
-            }
-
-            config = level_config.get(level, level_config["info"])
-            icon = config["icon"]
-            color = config["color"]
-
-            # デフォルトタイトル
-            if not title:
-                title = "YouTube Automation"
-
-            # 基本ペイロード
-            payload = {
-                "embeds": [
-                    {
-                        "color": int(color.replace("#", ""), 16),
-                        "title": f"{icon} {title}",
-                        "description": message,
-                        "footer": {"text": "YouTube Automation System"},
-                        "timestamp": datetime.fromtimestamp(time.time()).isoformat(),
-                    }
-                ]
-            }
-
-            # 追加フィールドがある場合
-            if fields:
-                discord_fields = []
-                for key, value in fields.items():
-                    discord_fields.append({"name": key, "value": str(value), "inline": True})
-                payload["embeds"][0]["fields"] = discord_fields
-
-            # Discord送信
-            response = httpx.post(self.webhook_url, json=payload, timeout=10.0)
-            response.raise_for_status()
-
-            logger.debug(f"Discord notification sent: {level} - {message[:50]}...")
+            async with self._client_factory() as client:
+                response = await client.post(self.webhook_url, json=payload)
+                response.raise_for_status()
+            logger.debug("Discord notification sent: %s - %s", level, message[:50])
             return True
-
-        except httpx.HTTPStatusError as e:
+        except httpx.HTTPStatusError as exc:
+            request_url = exc.request.url if exc.request else "N/A"
+            response_text = exc.response.text if exc.response else "<no response>"
             logger.error(
-                f"Failed to send Discord notification due to a client or server error: {e}\n"
-                f"URL: {e.request.url}\n"
-                f"Response: {e.response.text}"
+                "Failed to send Discord notification due to a client or server error: %s\n"
+                "URL: %s\n"
+                "Response: %s",
+                exc,
+                request_url,
+                response_text,
             )
             return False
-        except Exception as e:
-            logger.error(f"Failed to send Discord notification: {e}")
+        except Exception as exc:  # noqa: BLE001
+            logger.error("Failed to send Discord notification: %s", exc)
             return False
 
-    def notify_run_start(self, run_id: str, mode: str) -> bool:
-        """実行開始通知
+    def notify_blocking(
+        self,
+        message: str,
+        *,
+        level: str = "info",
+        title: Optional[str] = None,
+        fields: Optional[Dict[str, Any]] = None,
+    ) -> bool:
+        """Synchronously send a notification (runs its own event loop)."""
 
-        Args:
-            run_id: 実行ID
-            mode: 実行モード
+        return self._run_blocking(self.notify(message, level=level, title=title, fields=fields))
 
-        Returns:
-            送信成功時True
-
-        """
+    async def notify_run_start(self, run_id: str, mode: str) -> bool:
         message = "動画生成を開始しました"
         fields = {"実行ID": run_id, "モード": mode, "開始時刻": time.strftime("%Y-%m-%d %H:%M:%S")}
+        return await self.notify(message=message, level="info", title="🚀 実行開始", fields=fields)
 
-        return self.notify(message=message, level="info", title="🚀 実行開始", fields=fields)
+    def notify_run_start_blocking(self, run_id: str, mode: str) -> bool:
+        return self._run_blocking(self.notify_run_start(run_id, mode))
 
-    def notify_run_success(
-        self, run_id: str, duration_sec: int, video_url: Optional[str] = None, title: Optional[str] = None
+    async def notify_run_success(
+        self,
+        run_id: str,
+        duration_sec: int,
+        video_url: Optional[str] = None,
+        title: Optional[str] = None,
     ) -> bool:
-        """実行成功通知
-
-        Args:
-            run_id: 実行ID
-            duration_sec: 処理時間（秒）
-            video_url: 動画URL
-            title: 動画タイトル
-
-        Returns:
-            送信成功時True
-
-        """
         duration_min = duration_sec // 60
         duration_sec_remain = duration_sec % 60
 
         message = "動画生成が完了しました！"
-        fields = {
+        fields: Dict[str, Any] = {
             "実行ID": run_id,
             "処理時間": f"{duration_min}分{duration_sec_remain}秒",
             "完了時刻": time.strftime("%Y-%m-%d %H:%M:%S"),
@@ -147,22 +159,24 @@ class DiscordNotifier:
         if video_url:
             fields["動画URL"] = video_url
 
-        return self.notify(message=message, level="success", title="✅ 実行完了", fields=fields)
+        return await self.notify(message=message, level="success", title="✅ 実行完了", fields=fields)
 
-    def notify_run_error(self, run_id: str, error_message: str, step: Optional[str] = None) -> bool:
-        """実行エラー通知
+    def notify_run_success_blocking(
+        self,
+        run_id: str,
+        duration_sec: int,
+        video_url: Optional[str] = None,
+        title: Optional[str] = None,
+    ) -> bool:
+        return self._run_blocking(
+            self.notify_run_success(run_id, duration_sec, video_url=video_url, title=title)
+        )
 
-        Args:
-            run_id: 実行ID
-            error_message: エラーメッセージ
-            step: エラーが発生したステップ
-
-        Returns:
-            送信成功時True
-
-        """
+    async def notify_run_error(
+        self, run_id: str, error_message: str, step: Optional[str] = None
+    ) -> bool:
         message = "動画生成でエラーが発生しました"
-        fields = {
+        fields: Dict[str, Any] = {
             "実行ID": run_id,
             "エラー時刻": time.strftime("%Y-%m-%d %H:%M:%S"),
             "エラー": error_message[:200] + "..." if len(error_message) > 200 else error_message,
@@ -171,43 +185,36 @@ class DiscordNotifier:
         if step:
             fields["エラー箇所"] = step
 
-        return self.notify(message=message, level="error", title="❌ 実行失敗", fields=fields)
+        return await self.notify(message=message, level="error", title="❌ 実行失敗", fields=fields)
 
-    def notify_step_progress(self, run_id: str, step_name: str, progress: Optional[str] = None) -> bool:
-        """ステップ進捗通知
+    def notify_run_error_blocking(
+        self, run_id: str, error_message: str, step: Optional[str] = None
+    ) -> bool:
+        return self._run_blocking(self.notify_run_error(run_id, error_message, step))
 
-        Args:
-            run_id: 実行ID
-            step_name: ステップ名
-            progress: 進捗詳細
-
-        Returns:
-            送信成功時True
-
-        """
+    async def notify_step_progress(
+        self, run_id: str, step_name: str, progress: Optional[str] = None
+    ) -> bool:
         message = f"ステップ実行中: {step_name}"
-        fields = {"実行ID": run_id, "現在時刻": time.strftime("%H:%M:%S")}
+        fields: Dict[str, Any] = {"実行ID": run_id, "現在時刻": time.strftime("%H:%M:%S")}
 
         if progress:
             fields["詳細"] = progress
 
-        return self.notify(message=message, level="info", title="⏳ 進捗", fields=fields)
+        return await self.notify(message=message, level="info", title="⏳ 進捗", fields=fields)
 
-    def notify_status(
-        self, run_id: str, status: str, duration: Optional[int] = None, error: Optional[str] = None
+    def notify_step_progress_blocking(
+        self, run_id: str, step_name: str, progress: Optional[str] = None
     ) -> bool:
-        """詳細ステータス通知
+        return self._run_blocking(self.notify_step_progress(run_id, step_name, progress))
 
-        Args:
-            run_id: 実行ID
-            status: ステータス (started/completed/error)
-            duration: 処理時間（秒）
-            error: エラーメッセージ
-
-        Returns:
-            送信成功時True
-
-        """
+    async def notify_status(
+        self,
+        run_id: str,
+        status: str,
+        duration: Optional[int] = None,
+        error: Optional[str] = None,
+    ) -> bool:
         if status == "started":
             message = f"🚀 実行開始 (ID: {run_id})"
             level = "info"
@@ -216,11 +223,18 @@ class DiscordNotifier:
             duration_str = f"{duration}秒" if duration else "不明"
             message = f"✅ 実行完了 (ID: {run_id}, 処理時間: {duration_str})"
             level = "success"
-            fields = {"実行ID": run_id, "処理時間": duration_str, "完了時刻": time.strftime("%Y-%m-%d %H:%M:%S")}
+            fields = {
+                "実行ID": run_id,
+                "処理時間": duration_str,
+                "完了時刻": time.strftime("%Y-%m-%d %H:%M:%S"),
+            }
         elif status == "error":
             message = f"❌ 実行失敗 (ID: {run_id})"
             level = "error"
-            fields = {"実行ID": run_id, "エラー時刻": time.strftime("%Y-%m-%d %H:%M:%S")}
+            fields = {
+                "実行ID": run_id,
+                "エラー時刻": time.strftime("%Y-%m-%d %H:%M:%S"),
+            }
             if error:
                 fields["エラー"] = error[:200] + "..." if len(error) > 200 else error
         else:
@@ -228,42 +242,40 @@ class DiscordNotifier:
             level = "info"
             fields = {"実行ID": run_id, "ステータス": status}
 
-        return self.notify(message=message, level=level, fields=fields)
+        return await self.notify(message=message, level=level, fields=fields)
 
-    def notify_api_quota_warning(self, api_name: str, usage_info: str) -> bool:
-        """API使用量警告通知
+    def notify_status_blocking(
+        self, run_id: str, status: str, duration: Optional[int] = None, error: Optional[str] = None
+    ) -> bool:
+        return self._run_blocking(
+            self.notify_status(run_id, status=status, duration=duration, error=error)
+        )
 
-        Args:
-            api_name: API名
-            usage_info: 使用量情報
-
-        Returns:
-            送信成功時True
-
-        """
+    async def notify_api_quota_warning(self, api_name: str, usage_info: str) -> bool:
         message = f"{api_name} APIの使用量が上限に近づいています"
-        fields = {"API": api_name, "使用量情報": usage_info, "確認時刻": time.strftime("%Y-%m-%d %H:%M:%S")}
+        fields = {
+            "API": api_name,
+            "使用量情報": usage_info,
+            "確認時刻": time.strftime("%Y-%m-%d %H:%M:%S"),
+        }
+        return await self.notify(
+            message=message, level="warning", title="⚠️ API制限警告", fields=fields
+        )
 
-        return self.notify(message=message, level="warning", title="⚠️ API制限警告", fields=fields)
+    def notify_api_quota_warning_blocking(self, api_name: str, usage_info: str) -> bool:
+        return self._run_blocking(self.notify_api_quota_warning(api_name, usage_info))
 
-    def notify_system_health(self, health_data: Dict[str, Any]) -> bool:
-        """システムヘルスチェック通知
-
-        Args:
-            health_data: ヘルスチェック結果
-
-        Returns:
-            送信成功時True
-
-        """
-        # 全体のヘルス状況を判定
-        all_ok = all(status.get("configured", False) or status.get("status") == "OK" for status in health_data.values())
+    async def notify_system_health(self, health_data: Dict[str, Any]) -> bool:
+        all_ok = all(
+            status.get("configured", False) or status.get("status") == "OK"
+            for status in health_data.values()
+            if isinstance(status, dict)
+        )
 
         level = "success" if all_ok else "warning"
         message = "システムヘルスチェック結果"
 
-        # フィールドに結果を整理
-        fields = {}
+        fields: Dict[str, Any] = {}
         for service, status in health_data.items():
             if isinstance(status, dict):
                 if "configured" in status:
@@ -275,18 +287,12 @@ class DiscordNotifier:
             else:
                 fields[service] = str(status)
 
-        return self.notify(message=message, level=level, title="🏥 ヘルスチェック", fields=fields)
+        return await self.notify(message=message, level=level, title="🏥 ヘルスチェック", fields=fields)
 
-    def notify_daily_summary(self, summary_data: Dict[str, Any]) -> bool:
-        """日次サマリー通知
+    def notify_system_health_blocking(self, health_data: Dict[str, Any]) -> bool:
+        return self._run_blocking(self.notify_system_health(health_data))
 
-        Args:
-            summary_data: サマリーデータ
-
-        Returns:
-            送信成功時True
-
-        """
+    async def notify_daily_summary(self, summary_data: Dict[str, Any]) -> bool:
         total_runs = summary_data.get("total_runs", 0)
         successful_runs = summary_data.get("successful_runs", 0)
         failed_runs = summary_data.get("failed_runs", 0)
@@ -295,7 +301,7 @@ class DiscordNotifier:
         success_rate = (successful_runs / total_runs * 100) if total_runs > 0 else 0
 
         message = "本日の実行サマリー"
-        fields = {
+        fields: Dict[str, Any] = {
             "総実行数": f"{total_runs}回",
             "成功": f"{successful_runs}回",
             "失敗": f"{failed_runs}回",
@@ -303,72 +309,76 @@ class DiscordNotifier:
             "平均処理時間": f"{avg_duration // 60}分{avg_duration % 60}秒",
         }
 
-        # 生成された動画がある場合
         if "generated_videos" in summary_data:
             fields["生成動画数"] = f"{len(summary_data['generated_videos'])}本"
 
         level = "success" if failed_runs == 0 else ("warning" if success_rate >= 80 else "error")
 
-        return self.notify(message=message, level=level, title="📊 日次サマリー", fields=fields)
+        return await self.notify(message=message, level=level, title="📊 日次サマリー", fields=fields)
 
-    def test_notification(self) -> bool:
-        """テスト通知
+    def notify_daily_summary_blocking(self, summary_data: Dict[str, Any]) -> bool:
+        return self._run_blocking(self.notify_daily_summary(summary_data))
 
-        Returns:
-            送信成功時True
-
-        """
-        return self.notify(
+    async def test_notification(self) -> bool:
+        return await self.notify(
             message="Discord通知のテストメッセージです",
             level="info",
             title="🧪 テスト通知",
-            fields={"テスト時刻": time.strftime("%Y-%m-%d %H:%M:%S"), "システム": "YouTube Automation"},
+            fields={
+                "テスト時刻": time.strftime("%Y-%m-%d %H:%M:%S"),
+                "システム": "YouTube Automation",
+            },
         )
+
+    def test_notification_blocking(self) -> bool:
+        return self._run_blocking(self.test_notification())
 
 
 # グローバルインスタンス
 discord_notifier = DiscordNotifier()
 
 
-# 簡易アクセス関数
+# 非同期/同期アクセス関数
 def notify(message: str, level: str = "info") -> bool:
-    """基本通知の簡易関数"""
-    return discord_notifier.notify(message, level)
+    """基本通知の簡易関数 (同期)."""
+
+    return discord_notifier.notify_blocking(message, level=level)
 
 
 def notify_run_start(run_id: str, mode: str) -> bool:
-    """実行開始通知の簡易関数"""
-    return discord_notifier.notify_run_start(run_id, mode)
+    """実行開始通知の簡易関数 (同期)."""
+
+    return discord_notifier.notify_run_start_blocking(run_id, mode)
 
 
 def notify_run_success(
     run_id: str, duration_sec: int, video_url: Optional[str] = None, title: Optional[str] = None
 ) -> bool:
-    """実行成功通知の簡易関数"""
-    return discord_notifier.notify_run_success(run_id, duration_sec, video_url, title)
+    """実行成功通知の簡易関数 (同期)."""
+
+    return discord_notifier.notify_run_success_blocking(run_id, duration_sec, video_url, title)
 
 
 def notify_run_error(run_id: str, error_message: str, step: Optional[str] = None) -> bool:
-    """実行エラー通知の簡易関数"""
-    return discord_notifier.notify_run_error(run_id, error_message, step)
+    """実行エラー通知の簡易関数 (同期)."""
+
+    return discord_notifier.notify_run_error_blocking(run_id, error_message, step)
 
 
 def notify_step_progress(run_id: str, step_name: str, progress: Optional[str] = None) -> bool:
-    """ステップ進捗通知の簡易関数"""
-    return discord_notifier.notify_step_progress(run_id, step_name, progress)
+    """ステップ進捗通知の簡易関数 (同期)."""
+
+    return discord_notifier.notify_step_progress_blocking(run_id, step_name, progress)
 
 
 if __name__ == "__main__":
-    # テスト実行
     print("Testing Discord notifications...")
 
-    # 設定チェック
     print(f"Discord enabled: {discord_notifier.enabled}")
     if discord_notifier.enabled:
         print(f"Webhook URL configured: {bool(discord_notifier.webhook_url)}")
 
-        # テスト通知送信
-        result = discord_notifier.test_notification()
+        result = discord_notifier.test_notification_blocking()
         print(f"Test notification result: {result}")
     else:
         print("Discord not configured, skipping test")

--- a/app/main.py
+++ b/app/main.py
@@ -547,13 +547,19 @@ class YouTubeWorkflow:
     def _cleanup_temp_files(self):
         if not self.context:
             return
+        artifacts = self.context.artifacts
+        cleanup_targets = self.context.retention_policy.select_for_cleanup(artifacts)
         cleaned_count = 0
-        for file_path in self.context.generated_files:
-            if os.path.exists(file_path):
-                os.remove(file_path)
-                cleaned_count += 1
+        for artifact in cleanup_targets:
+            file_path = artifact.path
+            try:
+                if os.path.exists(file_path):
+                    os.remove(file_path)
+                    cleaned_count += 1
+            except OSError as exc:
+                logger.debug("Failed to remove artifact %s: %s", file_path, exc)
         if cleaned_count > 0:
-            logger.info(f"Cleaned up {cleaned_count} temporary files")
+            logger.info("Cleaned up %s temporary files", cleaned_count)
 
 
 def _get_workflow() -> YouTubeWorkflow:

--- a/app/notifications/interfaces.py
+++ b/app/notifications/interfaces.py
@@ -1,0 +1,21 @@
+"""Notification interfaces for workflow integrations."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class Notifier(Protocol):
+    """Asynchronous interface for workflow notifications."""
+
+    async def notify(
+        self,
+        message: str,
+        *,
+        level: str = "info",
+        title: Optional[str] = None,
+        fields: Optional[Dict[str, Any]] = None,
+    ) -> bool:
+        """Send a notification with optional metadata."""
+

--- a/app/services/media/fractions.py
+++ b/app/services/media/fractions.py
@@ -1,0 +1,44 @@
+"""Utility helpers for parsing ffprobe-style fraction strings."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class FractionParseResult:
+    """Represents the outcome of parsing a fraction string."""
+
+    value: float
+    is_valid: bool
+    raw: Optional[str] = None
+
+
+class FractionParser:
+    """Parses fraction strings like ``"30000/1001"`` from ffprobe metadata."""
+
+    def __init__(self, *, default: float = 0.0) -> None:
+        self._default = default
+
+    def parse(self, value: Optional[str]) -> FractionParseResult:
+        """Attempt to parse ``value`` into a float, falling back to ``default``."""
+
+        if value is None:
+            return FractionParseResult(self._default, False, value)
+
+        text = value.strip()
+        if not text:
+            return FractionParseResult(self._default, False, value)
+
+        try:
+            if "/" in text:
+                numerator_text, denominator_text = text.split("/", 1)
+                numerator = float(numerator_text)
+                denominator = float(denominator_text)
+                if denominator == 0:
+                    return FractionParseResult(self._default, False, value)
+                return FractionParseResult(numerator / denominator, True, value)
+            return FractionParseResult(float(text), True, value)
+        except (TypeError, ValueError):
+            return FractionParseResult(self._default, False, value)

--- a/app/web.py
+++ b/app/web.py
@@ -303,7 +303,7 @@ def discord_webhook():
         message = data.get("message", "Test message")
         level = data.get("level", "info")
 
-        discord_notifier.notify(message, level=level)
+        discord_notifier.notify_blocking(message, level=level)
 
         return jsonify({"success": True, "message": "Notification sent"})
 

--- a/app/workflow/__init__.py
+++ b/app/workflow/__init__.py
@@ -1,5 +1,6 @@
 """Workflow step abstraction for YouTube video generation pipeline."""
 
+from .artifacts import ArtifactRetentionPolicy, DefaultArtifactRetentionPolicy, GeneratedArtifact
 from .base import StepResult, WorkflowContext, WorkflowStep
 from .failure import FailureBus, WorkflowFailureEvent
 from .ports import NewsCollectionPort, SyncNewsCollectionAdapter
@@ -23,6 +24,9 @@ __all__ = [
     "WorkflowContext",
     "WorkflowStep",
     "StepResult",
+    "GeneratedArtifact",
+    "ArtifactRetentionPolicy",
+    "DefaultArtifactRetentionPolicy",
     "FailureBus",
     "WorkflowFailureEvent",
     "NewsCollectionPort",

--- a/app/workflow/__init__.py
+++ b/app/workflow/__init__.py
@@ -1,6 +1,8 @@
 """Workflow step abstraction for YouTube video generation pipeline."""
 
 from .base import StepResult, WorkflowContext, WorkflowStep
+from .failure import FailureBus, WorkflowFailureEvent
+from .ports import NewsCollectionPort, SyncNewsCollectionAdapter
 from .steps import (
     AlignSubtitlesStep,
     CollectNewsStep,
@@ -21,6 +23,10 @@ __all__ = [
     "WorkflowContext",
     "WorkflowStep",
     "StepResult",
+    "FailureBus",
+    "WorkflowFailureEvent",
+    "NewsCollectionPort",
+    "SyncNewsCollectionAdapter",
     "CollectNewsStep",
     "GenerateScriptStep",
     "GenerateVisualDesignStep",

--- a/app/workflow/artifacts.py
+++ b/app/workflow/artifacts.py
@@ -1,0 +1,59 @@
+"""Workflow artifact modeling and retention policies."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List, Sequence
+
+
+@dataclass(frozen=True)
+class GeneratedArtifact:
+    """Represents a file produced by the workflow."""
+
+    path: str
+    persisted: bool = False
+    cleanup: bool = True
+    kind: str | None = None
+    description: str | None = None
+
+    @classmethod
+    def from_path(cls, path: str, *, persisted: bool = False, cleanup: bool = True, **kwargs: object) -> "GeneratedArtifact":
+        """Convenience constructor that mirrors the dataclass signature."""
+
+        return cls(path=path, persisted=persisted, cleanup=cleanup, **kwargs)
+
+    @property
+    def should_cleanup(self) -> bool:
+        """Return True when the artifact is eligible for deletion."""
+
+        return self.cleanup and not self.persisted
+
+
+class ArtifactRetentionPolicy:
+    """Strategy for selecting which artifacts should be removed."""
+
+    def select_for_cleanup(self, artifacts: Sequence[GeneratedArtifact]) -> List[GeneratedArtifact]:
+        """Return artifacts that should be deleted."""
+
+        raise NotImplementedError
+
+
+class DefaultArtifactRetentionPolicy(ArtifactRetentionPolicy):
+    """Retention strategy that preserves persisted artifacts."""
+
+    def select_for_cleanup(self, artifacts: Sequence[GeneratedArtifact]) -> List[GeneratedArtifact]:
+        return [artifact for artifact in artifacts if artifact.should_cleanup]
+
+
+def ensure_artifact(item: str | GeneratedArtifact) -> GeneratedArtifact:
+    """Normalize raw file specs into :class:`GeneratedArtifact` objects."""
+
+    if isinstance(item, GeneratedArtifact):
+        return item
+    return GeneratedArtifact(path=item)
+
+
+def ensure_artifacts(items: Iterable[str | GeneratedArtifact]) -> List[GeneratedArtifact]:
+    """Normalize an iterable of artifact specs."""
+
+    return [ensure_artifact(item) for item in items]

--- a/app/workflow/failure.py
+++ b/app/workflow/failure.py
@@ -1,0 +1,42 @@
+"""Failure bus primitives for the asynchronous workflow pipeline."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable, List, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - circular import guard for type checking only
+    from .base import WorkflowContext
+
+
+@dataclass
+class WorkflowFailureEvent:
+    """Payload describing a workflow failure notification."""
+
+    step_name: str
+    context: Optional["WorkflowContext"]
+    result: Optional[Any] = None
+    error: Optional[BaseException] = None
+    response: Optional[Any] = None
+
+
+FailureSubscriber = Callable[[WorkflowFailureEvent], Awaitable[None]]
+
+
+class FailureBus:
+    """Simple async pub/sub bus for workflow failure events."""
+
+    def __init__(self) -> None:
+        self._subscribers: List[FailureSubscriber] = []
+
+    def subscribe(self, subscriber: FailureSubscriber) -> None:
+        """Register a subscriber that will be awaited when a failure occurs."""
+
+        self._subscribers.append(subscriber)
+
+    async def notify(self, event: WorkflowFailureEvent) -> WorkflowFailureEvent:
+        """Notify all subscribers sequentially and return the enriched event."""
+
+        for subscriber in self._subscribers:
+            await subscriber(event)
+        return event

--- a/app/workflow/ports.py
+++ b/app/workflow/ports.py
@@ -1,0 +1,24 @@
+"""Workflow port definitions for asynchronous orchestration."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from typing import Any, Dict, List, Protocol
+
+
+class NewsCollectionPort(Protocol):
+    """Abstract port for collecting news items asynchronously."""
+
+    async def collect_news(self, prompt: str, mode: str) -> List[Dict[str, Any]]:
+        """Collect news articles for the given prompt and workflow mode."""
+
+
+class SyncNewsCollectionAdapter:
+    """Adapter that offloads synchronous news collection to a worker thread."""
+
+    def __init__(self, collector: Callable[[str, str], List[Dict[str, Any]]]):
+        self._collector = collector
+
+    async def collect_news(self, prompt: str, mode: str) -> List[Dict[str, Any]]:
+        return await asyncio.to_thread(self._collector, prompt, mode)

--- a/docs/code_review.md
+++ b/docs/code_review.md
@@ -1,0 +1,75 @@
+# コードレビュー所見（批判的レビュー）
+
+## 1. Perplexityニュース収集が構成キーに強く依存しすぎており、実質的に無効化されている
+- `app/search_news.py` のグローバル初期化は `cfg.perplexity_api_key` が設定されている場合にしか `NewsCollector` を作成しません。【F:app/search_news.py†L337-L346】
+- ところが `NewsCollector` 自体は `PERPLEXITY_API_KEY_2` 以降の環境変数をサポートしており、キーローテーション前提の設計です。【F:app/search_news.py†L52-L109】
+- `cfg.perplexity_api_key`（=設定ファイル内の `api_keys.perplexity`）が空でも、環境変数側にキーがセットされていることは十分にあり得ます。その場合でもグローバルは `None` なので、`collect_news` は強制的にフォールバックニュースを返してしまい、本番環境で常にダミーデータしか得られません。【F:app/search_news.py†L337-L346】
+- 少なくとも lazy 初期化で `NewsCollector` を試行するか、ローテーションマネージャーにキーが1件でも登録されていれば API 呼び出しへ進むよう修正すべきです。
+
+### 推奨対策（疎結合・テスト容易性）
+- `NewsCollector` を生成するファクトリ関数を新設し、設定値と環境変数の両方からキーを集約する `KeyProvider` インターフェースを切り出します。これにより依存箇所は `KeyProvider` の抽象に依存し、ユニットテストではフェイク実装を差し替え可能です。
+- グローバル状態ではなく、ステップ実行時にファクトリから `NewsCollector` を取得する設計へ変更し、`pytest` で `KeyProvider` の戻り値をモックしてキー探索の分岐をテストします。
+- キー未設定時にフォールバックへ切り替わる挙動を `tests/unit/search_news/test_collector_factory.py` のようなファイルでカバレッジします。
+
+## 2. ワークフローステップの例外処理が欠落し、1ステップの未捕捉例外で全体が異常終了する
+- `YouTubeWorkflow.execute_full_workflow` のループでは各ステップを `await step.execute(...)` で呼び出していますが、例外を捕捉していません。【F:app/main.py†L106-L141】
+- どこかのステップが `StepResult` を返す前に例外を送出すると、`_handle_workflow_failure` や `self._cleanup_temp_files()` が実行されず、ログ/Discord通知/リトライ処理が一切走らないままコルーチンが失敗します。
+- 実際に各ステップは広範囲で `except Exception` を握り潰していますが、新規ステップや外部ライブラリの変更で例外が漏れると致命的です。最低限、`step.execute` 呼び出し自体を try/except で囲い、`_handle_workflow_failure` を通して失敗を一元処理する必要があります。
+
+### 推奨対策（疎結合・テスト容易性）
+- ステップを `WorkflowStep` 抽象でラップし、例外発生時には `WorkflowFailure` イベントを発行する `FailureBus` を導入します。`FailureBus` はサブスクライバ（通知、クリーンアップ）に依存性注入で渡すことで疎結合になります。
+- `execute_full_workflow` は `try/except` 内で `FailureBus.notify()` を呼ぶのみとし、副作用はリスナーへ委譲することでテストではフェイクリスナーで検証可能です。
+- ユニットテストで `MockStep` が例外を送出した際に `FailureBus` が通知したか、`_cleanup_temp_files` が呼ばれたかを `tests/unit/workflow/test_failure_bus.py` のようなモジュールで確認します。
+
+## 3. Discord 通知は同期 HTTP 呼び出しのため、イベントループをブロックする
+- `_notify_workflow_start` / `_notify_workflow_success` / `_notify_workflow_error` はすべて `discord_notifier.notify(...)` を直接呼びますが、`discord_notifier` は内部で `httpx.post` を同期で実行しています。【F:app/main.py†L440-L475】【F:app/discord.py†L47-L84】
+- ワークフローは asyncio ベースなのに、各ステップ間で10秒タイムアウトの同期 HTTP を行うため、その間イベントループ全体がブロックされます。メディア生成など重い処理と平行してログ送信を行いたい場面でレスポンス遅延やタイムアウトを引き起こしかねません。
+- 少なくとも `asyncio.to_thread` でオフロードするか、`httpx.AsyncClient` に置き換えて await するべきです。
+
+### 推奨対策（疎結合・テスト容易性）
+- `Notifier` プロトコルを定義し、Discord 実装と将来の Slack/メール実装を同一インターフェースで扱えるようにします。ワークフロー側は `Notifier` にのみ依存し、同期・非同期実装を DI で差し替え可能とします。
+- HTTP 呼び出しは `httpx.AsyncClient` を使った非同期クライアントに置き換え、`AsyncNotifier` は `Notifier` プロトコルを実装した `Async` クラスとしてテストで `respx` などの HTTP モックを利用できるようにします。
+- `tests/unit/notifications/test_async_notifier.py` を作成し、イベントループがブロックされないことを `asyncio` テストで検証します。
+
+## 4. ffprobe の `r_frame_rate` が "N/A" の場合に QA ステップがクラッシュする
+- `MediaQAPipeline._parse_fraction` は入力を無条件で `float(...)` に変換しており、`ffprobe` が "N/A" を返すケース（可変フレームレートなど）を考慮していません。【F:app/services/media/qa_pipeline.py†L401-L408】
+- その結果 `ValueError` が発生し、`_run_video_checks` 全体が例外で終わるため、`QualityAssuranceStep` が失敗してワークフロー全体が停止します。`subprocess.CalledProcessError` などは捕捉しているのに、解析結果の欠損まではハンドリングしていないのは危険です。
+- 想定外の値は 0fps 扱いにフォールバックする、あるいは `try/except ValueError` を追加してワーニングのみに留めるべきです。
+
+### 推奨対策（疎結合・テスト容易性）
+- `_parse_fraction` を純粋関数として切り出し、入力バリデーションを `FractionParser` のような小さなユーティリティに移します。これによりメディア QA 本体からロジックが分離され、ユニットテストしやすくなります。
+- `OptionalFraction` 型（`typing.Protocol` でも可）で `N/A` のような非数値文字列も受け取り、`Result` オブジェクトでエラーと成功を表現することで、呼び出し側は例外ではなく戻り値で分岐可能になります。
+- `tests/unit/media/test_fraction_parser.py` を追加し、`"30000/1001"` や `"N/A"` のケースを網羅して回帰テストを実施します。
+
+## 5. 主要ステップが非同期 API なのにすべて同期 I/O を内部で呼び出している
+- 代表例として `CollectNewsStep` は `collect_news` をそのまま呼びますが、内部で `httpx.Client` を同期利用しておりネットワーク I/O がイベントループをブロックします。【F:app/workflow/steps.py†L34-L69】【F:app/search_news.py†L100-L163】
+- 同様に TTS や動画生成ステップも同期的な重処理を直接呼び出しており、`async` の表面 API でありながら本質的にブロッキングです。今後 UI や API から並列実行した場合にスループットが大幅に低下し、タイムアウトやデッドロックにつながる懸念があります。
+- すくなくともネットワーク/ディスク I/O は `asyncio.to_thread` ないし専用の非同期クライアントで実装し直すことを推奨します。
+
+### 推奨対策（疎結合・テスト容易性）
+- I/O を伴う処理を `Port` / `Adapter` パターンで分離し、`CollectNewsPort` や `TTSPort` を抽象化します。ワークフローステップは `Port` の抽象メソッドを await するだけにし、実装は同期・非同期の差分を隠蔽します。
+- 同期処理を残す場合も `asyncio.to_thread` をラップしたアダプタに封じ込めることで、ユニットテストではインメモリフェイクを注入し、非同期テストでも `pytest.mark.asyncio` で検証可能です。
+- `tests/unit/workflow/test_collect_news_step.py` を追加し、`Port` のフェイクを注入してステップの状態遷移と戻り値を検証します。
+
+## 6. QA リトライ時のコンテキストクリーンアップはファイルを削除してもアーカイブ先を考慮していない
+- `GenerateVideoStep` では `FileArchivalManager` で生成物を `output/` にコピーした後、`result.files_generated` に元の一時ファイル（例: B-roll 含む）パスを入れています。【F:app/workflow/steps.py†L232-L324】
+- `_cleanup_temp_files` は `context.generated_files` を無条件に削除するため、QA リトライ後に必要な中間生成物まで消えてしまう可能性があります。特に B-roll 生成を再利用する仕組みがなく、リトライごとに高コストな再生成が走る設計です。【F:app/main.py†L488-L500】
+- アーカイブ後に参照するファイルと、再生成が安価なテンポラリを区別する仕組みを導入すべきです。
+
+### 推奨対策（疎結合・テスト容易性）
+- `GeneratedArtifact` エンティティを導入し、`persisted=True/False` などのメタデータを持たせることで、クリーンアップロジックはメタデータに従って削除可否を判断できます。`WorkflowContext` は単純なデータコンテナとし、削除ポリシーは `ArtifactRetentionPolicy` クラスへ委譲することで責務を分離します。
+- `ArtifactRetentionPolicy` を `Strategy` パターンで差し替えられるようにし、テストでは `InMemoryFileSystem` を利用して削除対象を検証します。
+- `tests/unit/workflow/test_artifact_retention_policy.py` を追加し、QA リトライ時にアーカイブ済みファイルが保持されることを保証します。
+
+## 7. 例外時の Discord 通知がエラーオブジェクト文字列依存で詳細が欠落する
+- `_handle_workflow_failure` は `result.error` が存在しない場合 `str(result)` を使いますが、未捕捉例外で `result` が `None` の場合 "None" という情報量ゼロのメッセージになります。【F:app/main.py†L195-L217】
+- `traceback` や `exc_info` を Discord 通知へ含めないと、運用時に原因解析が困難です。
+
+### 推奨対策（疎結合・テスト容易性）
+- エラー通知生成を `FailureReportBuilder` として独立させ、`Exception` と `WorkflowContext` からサマリ・詳細・トレースバックを組み立てる責務を切り出します。通知システムは `Report` の抽象にのみ依存し、将来的な通知チャネル追加時にもロジックを再利用できます。
+- 生成されたレポートは JSON などシリアライズ可能な形式にし、ユニットテストでトレースバックが含まれることをアサートします。
+- `tests/unit/notifications/test_failure_report_builder.py` を追加し、例外が `None` の場合やメッセージのみの場合などをカバーします。
+
+---
+
+上記の問題は可用性・保守性に直接影響し、特に 1〜4 は即時修正を推奨します。

--- a/tests/unit/media/test_fraction_parser.py
+++ b/tests/unit/media/test_fraction_parser.py
@@ -1,0 +1,44 @@
+import pytest
+
+from app.services.media.fractions import FractionParser
+
+
+@pytest.mark.unit
+class TestFractionParser:
+    def setup_method(self) -> None:
+        self.parser = FractionParser()
+
+    def test_parses_fraction_string(self) -> None:
+        result = self.parser.parse("30000/1001")
+        assert result.is_valid
+        assert result.value == pytest.approx(29.97002997, rel=1e-6)
+
+    def test_parses_decimal_string(self) -> None:
+        result = self.parser.parse("24.0")
+        assert result.is_valid
+        assert result.value == pytest.approx(24.0)
+
+    def test_handles_na_value(self) -> None:
+        result = self.parser.parse("N/A")
+        assert not result.is_valid
+        assert result.value == 0.0
+
+    def test_handles_empty_string(self) -> None:
+        result = self.parser.parse("")
+        assert not result.is_valid
+        assert result.value == 0.0
+
+    def test_handles_none(self) -> None:
+        result = self.parser.parse(None)
+        assert not result.is_valid
+        assert result.value == 0.0
+
+    def test_handles_zero_denominator(self) -> None:
+        result = self.parser.parse("1/0")
+        assert not result.is_valid
+        assert result.value == 0.0
+
+    def test_strips_whitespace(self) -> None:
+        result = self.parser.parse("  60000 / 1001  ")
+        assert result.is_valid
+        assert result.value == pytest.approx(59.94005994, rel=1e-6)

--- a/tests/unit/notifications/test_discord_notifier.py
+++ b/tests/unit/notifications/test_discord_notifier.py
@@ -1,0 +1,98 @@
+"""Tests for the asynchronous Discord notifier implementation."""
+
+import asyncio
+from typing import Any, Dict, List
+
+import httpx
+import pytest
+
+from app.discord import DiscordNotifier
+
+
+class _DummyResponse:
+    def raise_for_status(self) -> None:  # pragma: no cover - no-op success path
+        return None
+
+
+class _TrackingClient:
+    def __init__(self, tracker: List[Dict[str, Any]]):
+        self._tracker = tracker
+
+    async def __aenter__(self) -> "_TrackingClient":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    async def post(self, url: str, json: Dict[str, Any]) -> _DummyResponse:
+        self._tracker.append({"url": url, "payload": json})
+        return _DummyResponse()
+
+
+class _ErroringClient:
+    async def __aenter__(self) -> "_ErroringClient":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    async def post(self, url: str, json: Dict[str, Any]) -> _DummyResponse:
+        request = httpx.Request("POST", url)
+        response = httpx.Response(500, request=request, text="failure")
+        raise httpx.HTTPStatusError("boom", request=request, response=response)
+
+
+@pytest.mark.asyncio
+async def test_notify_returns_false_when_disabled() -> None:
+    notifier = DiscordNotifier(webhook_url="", client_factory=lambda: _TrackingClient([]))
+
+    assert notifier.enabled is False
+
+    result = await notifier.notify("hello")
+
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_notify_uses_async_client_factory() -> None:
+    tracker: List[Dict[str, Any]] = []
+    notifier = DiscordNotifier(
+        webhook_url="https://example.com/hook",
+        client_factory=lambda: _TrackingClient(tracker),
+    )
+
+    result = await notifier.notify("message", level="success", title="Title", fields={"foo": "bar"})
+
+    assert result is True
+    assert tracker
+    call = tracker[0]
+    assert call["url"] == "https://example.com/hook"
+    embed = call["payload"]["embeds"][0]
+    assert embed["title"].startswith("✅")
+    assert any(field["name"] == "foo" for field in embed.get("fields", []))
+
+
+@pytest.mark.asyncio
+async def test_notify_handles_http_errors() -> None:
+    notifier = DiscordNotifier(
+        webhook_url="https://example.com/hook",
+        client_factory=lambda: _ErroringClient(),
+    )
+
+    result = await notifier.notify("message", level="error")
+
+    assert result is False
+
+
+def test_notify_blocking_runs_async_path() -> None:
+    tracker: List[Dict[str, Any]] = []
+    notifier = DiscordNotifier(
+        webhook_url="https://example.com/hook",
+        client_factory=lambda: _TrackingClient(tracker),
+        run_sync=asyncio.run,
+    )
+
+    result = notifier.notify_blocking("blocking-call", level="debug")
+
+    assert result is True
+    assert tracker[0]["payload"]["embeds"][0]["title"].startswith("🔧")

--- a/tests/unit/workflow/test_artifact_retention_policy.py
+++ b/tests/unit/workflow/test_artifact_retention_policy.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+
+import pytest
+
+from app.main import YouTubeWorkflow
+from app.workflow.artifacts import DefaultArtifactRetentionPolicy, GeneratedArtifact
+from app.workflow.base import WorkflowContext
+
+
+@pytest.mark.unit
+def test_default_policy_preserves_persisted_artifacts():
+    policy = DefaultArtifactRetentionPolicy()
+    ephemeral = GeneratedArtifact(path="/tmp/ephemeral.txt")
+    persisted = GeneratedArtifact(path="/tmp/persisted.txt", persisted=True)
+
+    cleanup_targets = policy.select_for_cleanup([ephemeral, persisted])
+
+    assert cleanup_targets == [ephemeral]
+
+
+@pytest.mark.unit
+def test_cleanup_skips_persisted_files(tmp_path: Path):
+    workflow = YouTubeWorkflow(notifier=None)
+    context = WorkflowContext(run_id="run-123", mode="test")
+    workflow.context = context
+
+    ephemeral_path = tmp_path / "temp.txt"
+    archived_path = tmp_path / "archived.txt"
+    ephemeral_path.write_text("temp")
+    archived_path.write_text("archive")
+
+    context.add_files(
+        [
+            GeneratedArtifact(path=str(ephemeral_path)),
+            GeneratedArtifact(path=str(archived_path), persisted=True),
+        ]
+    )
+
+    workflow._cleanup_temp_files()
+
+    assert not ephemeral_path.exists()
+    assert archived_path.exists()

--- a/tests/unit/workflow/test_collect_news_step.py
+++ b/tests/unit/workflow/test_collect_news_step.py
@@ -1,0 +1,75 @@
+import threading
+from typing import Any, Dict, List
+
+import pytest
+
+from app.workflow.base import StepResult, WorkflowContext
+from app.workflow.ports import SyncNewsCollectionAdapter
+from app.workflow.steps import CollectNewsStep
+
+
+class _FakePort:
+    def __init__(self, results: List[Dict[str, Any]]):
+        self.results = results
+        self.calls: List[tuple[str, str]] = []
+
+    async def collect_news(self, prompt: str, mode: str) -> List[Dict[str, Any]]:
+        self.calls.append((prompt, mode))
+        return list(self.results)
+
+
+class _ExplodingPort:
+    async def collect_news(self, prompt: str, mode: str) -> List[Dict[str, Any]]:  # type: ignore[override]
+        raise RuntimeError("network down")
+
+
+@pytest.mark.asyncio
+async def test_collect_news_step_success(monkeypatch):
+    monkeypatch.setattr("app.workflow.steps.sheets_manager", None, raising=False)
+    context = WorkflowContext(run_id="run-1", mode="daily")
+    fake_items = [{"title": "headline", "url": "https://example.com", "summary": "ok", "source": "unit"}]
+    port = _FakePort(fake_items)
+    step = CollectNewsStep(news_port=port)
+
+    result = await step.execute(context)
+
+    assert isinstance(result, StepResult)
+    assert result.success is True
+    assert result.data == {"news_items": fake_items, "count": len(fake_items)}
+    assert context.get("news_items") == fake_items
+    assert len(port.calls) == 1
+    recorded_prompt, recorded_mode = port.calls[0]
+    assert recorded_mode == "daily"
+    assert isinstance(recorded_prompt, str) and recorded_prompt
+
+
+@pytest.mark.asyncio
+async def test_collect_news_step_failure_on_exception(monkeypatch):
+    monkeypatch.setattr("app.workflow.steps.sheets_manager", None, raising=False)
+    context = WorkflowContext(run_id="run-1", mode="daily")
+    step = CollectNewsStep(news_port=_ExplodingPort())
+
+    result = await step.execute(context)
+
+    assert result.success is False
+    assert "network down" in result.error
+
+
+@pytest.mark.asyncio
+async def test_sync_adapter_runs_collector_in_background_thread():
+    main_thread = threading.get_ident()
+    calls: list[tuple[str, str]] = []
+    worker_threads: list[int] = []
+
+    def blocking_collector(prompt: str, mode: str) -> List[Dict[str, Any]]:
+        calls.append((prompt, mode))
+        worker_threads.append(threading.get_ident())
+        return [{"title": prompt, "url": "u", "summary": "s", "source": mode}]
+
+    adapter = SyncNewsCollectionAdapter(blocking_collector)
+    result = await adapter.collect_news("prompt", "mode")
+
+    assert result[0]["title"] == "prompt"
+    assert calls == [("prompt", "mode")]
+    assert threading.get_ident() == main_thread
+    assert worker_threads and worker_threads[0] != main_thread

--- a/tests/unit/workflow/test_failure_bus.py
+++ b/tests/unit/workflow/test_failure_bus.py
@@ -1,0 +1,70 @@
+import asyncio
+
+import pytest
+
+from app.main import YouTubeWorkflow
+from app.workflow import FailureBus, WorkflowContext, WorkflowFailureEvent, WorkflowStep
+
+
+@pytest.mark.asyncio
+async def test_failure_bus_notifies_subscribers():
+    bus = FailureBus()
+    observed = []
+
+    async def subscriber(event: WorkflowFailureEvent) -> None:
+        observed.append((event.step_name, event.error))
+        event.response = {"handled": True}
+
+    bus.subscribe(subscriber)
+
+    event = WorkflowFailureEvent(step_name="unit", context=None)
+    enriched = await bus.notify(event)
+
+    assert observed == [("unit", None)]
+    assert enriched.response == {"handled": True}
+
+
+class _ExplodingStep(WorkflowStep):
+    step_name = "exploding_step"
+
+    async def execute(self, context: WorkflowContext):  # type: ignore[override]
+        raise RuntimeError("boom")
+
+
+@pytest.mark.asyncio
+async def test_workflow_exception_routes_through_failure_bus(monkeypatch):
+    workflow = YouTubeWorkflow()
+    workflow.steps = [_ExplodingStep()]
+    workflow._log_session = None  # type: ignore[assignment]
+
+    monkeypatch.setattr(workflow, "_initialize_run", lambda mode: "run-123", raising=False)
+
+    async def noop(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(workflow, "_notify_workflow_start", noop, raising=False)
+    monkeypatch.setattr(workflow, "_notify_workflow_success", noop, raising=False)
+
+    notified_errors = []
+
+    async def capture_error(error):
+        notified_errors.append(str(error))
+
+    monkeypatch.setattr(workflow, "_notify_workflow_error", capture_error, raising=False)
+    monkeypatch.setattr(workflow, "_update_run_status", lambda *args, **kwargs: None, raising=False)
+
+    cleanup_called = asyncio.Event()
+
+    def record_cleanup():
+        cleanup_called.set()
+
+    monkeypatch.setattr(workflow, "_cleanup_temp_files", record_cleanup, raising=False)
+
+    result = await workflow.execute_full_workflow("unit-test")
+
+    assert result["success"] is False
+    assert result["failed_step"] == "exploding_step"
+    assert result["error"] == "boom"
+    assert result["run_id"] == "run-123"
+    assert notified_errors and "boom" in notified_errors[0]
+    assert cleanup_called.is_set()


### PR DESCRIPTION
## Summary
- extract a `NewsCollectionPort` and `SyncNewsCollectionAdapter` so blocking HTTP clients can be offloaded from the event loop
- refactor `CollectNewsStep` to depend on the asynchronous port abstraction and keep prompts recorded via the workflow context
- add workflow unit tests to cover success/error paths and confirm the adapter executes in a background thread

## Testing
- pytest tests/unit/workflow/test_collect_news_step.py

------
https://chatgpt.com/codex/tasks/task_e_68e44e31fcb88325bf2467e386c73608