### PR TITLE
fix: decode wrapped script payloads

### DIFF
--- a/tests/unit/services/script/test_generator_parsing.py
+++ b/tests/unit/services/script/test_generator_parsing.py
@@ -1,5 +1,7 @@
 """Tests for extracting structured JSON from LLM responses."""
 
+from unittest.mock import MagicMock
+
 from app.services.script.generator import StructuredScriptGenerator
 
 
@@ -21,3 +23,12 @@ def test_extract_json_block_handles_markdown_code_blocks():
     extracted = StructuredScriptGenerator._extract_json_block(markdown)
 
     assert extracted == '{\n  "title": "Test",\n  "dialogues": []\n}'
+
+
+def test_parse_payload_handles_wrapped_json_string():
+    generator = StructuredScriptGenerator(client=MagicMock(), allowed_speakers=("話者A", "話者B"))
+
+    payload = generator._parse_payload('"{\\"title\\": \\"Wrapped\\", \\"dialogues\\": []}"')
+
+    assert payload.title == "Wrapped"
+    assert payload.dialogues == []


### PR DESCRIPTION
## Summary
- allow the structured script generator to recover JSON objects that are wrapped in escaped strings
- add unit coverage for parsing string-wrapped responses

## Testing
- pytest tests/unit/services/script/test_generator_parsing.py

------
https://chatgpt.com/codex/tasks/task_e_68e466a552448325a9364c5f16c5d2c2