### PR TITLE
fix: recover structured script fallback parsing

### DIFF
--- a/tests/unit/services/script/test_generator_parsing.py
+++ b/tests/unit/services/script/test_generator_parsing.py
@@ -1,6 +1,13 @@
 """Tests for extracting structured JSON from LLM responses."""
 
+from types import SimpleNamespace
+
 from app.services.script.generator import StructuredScriptGenerator
+
+
+def _make_generator() -> StructuredScriptGenerator:
+    dummy_client = SimpleNamespace(completion=None)
+    return StructuredScriptGenerator(client=dummy_client, allowed_speakers=('ナビゲーター', 'アナリスト', 'リポーター'))
 
 
 def test_extract_json_block_skips_non_json_braces():
@@ -21,3 +28,27 @@ def test_extract_json_block_handles_markdown_code_blocks():
     extracted = StructuredScriptGenerator._extract_json_block(markdown)
 
     assert extracted == '{\n  "title": "Test",\n  "dialogues": []\n}'
+
+
+def test_build_script_from_text_recovers_structured_payload():
+    generator = _make_generator()
+    response_text = (
+        "```json\n"
+        '{\n'
+        '  "title": "最新ニュース徹底解説",\n'
+        '  "dialogues": [\n'
+        '    {"speaker": "ナビゲーター", "line": "こんばんは、きょうのマーケットを整理します。"},\n'
+        '    {"speaker": "アナリスト", "line": "まずは日経平均の動きから見ていきましょう。"}\n'
+        '  ]\n'
+        '}\n'
+        "```"
+    )
+
+    script, report = generator._build_script_from_text(response_text)
+
+    assert script.title == '最新ニュース徹底解説'
+    assert [entry.line for entry in script.dialogues[:2]] == [
+        'こんばんは、きょうのマーケットを整理します。',
+        'まずは日経平均の動きから見ていきましょう。',
+    ]
+    assert report.dialogue_lines >= 2


### PR DESCRIPTION
## Summary
- recover structured script payloads during fallback parsing by probing JSON/YAML candidates
- strip markdown fences when searching for structured content and reuse the structured metadata when possible
- add a regression test proving fallback recovery keeps Japanese dialogue content intact

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e46932bc90832583aa83670dc75a07