### PR TITLE
refactor: persist llm interaction logs as yaml

### DIFF
--- a/app/crew/agent_review.py
+++ b/app/crew/agent_review.py
@@ -7,7 +7,6 @@ improving automatically.
 
 from __future__ import annotations
 
-import json
 import logging
 import os
 import re
@@ -59,7 +58,7 @@ class AgentReviewResult(BaseModel):
 class AgentReviewStorage:
     """Persistence layer for agent reviews."""
 
-    def __init__(self, storage_path: str = "data/agent_reviews.json") -> None:
+    def __init__(self, storage_path: str = "data/agent_reviews.yaml") -> None:
         self.storage_path = storage_path
         self._data: Dict[str, Dict[str, object]] = self._load()
 
@@ -68,17 +67,17 @@ class AgentReviewStorage:
             return {}
         try:
             with open(self.storage_path, "r", encoding="utf-8") as handle:
-                data = json.load(handle)
+                data = yaml.safe_load(handle)
                 if isinstance(data, dict):
                     return data
-        except (OSError, ValueError) as exc:
+        except (OSError, yaml.YAMLError) as exc:
             logger.warning("Failed to load agent review storage: %s", exc)
         return {}
 
     def save(self) -> None:
         os.makedirs(os.path.dirname(self.storage_path) or ".", exist_ok=True)
         with open(self.storage_path, "w", encoding="utf-8") as handle:
-            json.dump(self._data, handle, ensure_ascii=False, indent=2)
+            yaml.safe_dump(self._data, handle, allow_unicode=True, sort_keys=False)
 
     def append(self, result: AgentReviewResult) -> None:
         payload = result.model_dump(mode="json")

--- a/app/services/script/continuity.py
+++ b/app/services/script/continuity.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 import csv
-import json
 import re
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
+
+import yaml
 
 
 @dataclass
@@ -84,7 +85,7 @@ class ContinuityContextBuilder:
         data_dir = project_root / "data"
 
         self.metadata_csv_path = Path(metadata_csv_path or data_dir / "metadata_history.csv")
-        self.feedback_json_path = Path(feedback_json_path or data_dir / "video_feedback.json")
+        self.feedback_json_path = Path(feedback_json_path or data_dir / "video_feedback.yaml")
 
     def build_prompt_snippet(self) -> str:
         metadata = self._load_latest_metadata()
@@ -174,7 +175,7 @@ class ContinuityContextBuilder:
 
         try:
             with self.feedback_json_path.open("r", encoding="utf-8") as f:
-                data = json.load(f)
+                data = yaml.safe_load(f)
             if isinstance(data, dict) and data:
                 return data
         except Exception:

--- a/tests/unit/services/test_file_archival_manager.py
+++ b/tests/unit/services/test_file_archival_manager.py
@@ -1,7 +1,8 @@
-import json
 from pathlib import Path
 
 import pytest
+
+import yaml
 
 from app.services.file_archival import FileArchivalManager
 
@@ -25,7 +26,7 @@ def test_list_archived_workflows_parses_run_id_with_underscores(tmp_path):
         title="Daily Recap",
     )
 
-    metadata = json.loads((first_dir / ".archive_meta.json").read_text())
+    metadata = yaml.safe_load((first_dir / ".archive_meta.yaml").read_text())
     assert metadata["run_id"] == "local_20250101_123456"
     assert metadata["timestamp"] == "20240101_010101"
     assert metadata["sanitized_title"] == manager.sanitize_title("Market News: Update")

--- a/tests/unit/test_llm_logging.py
+++ b/tests/unit/test_llm_logging.py
@@ -1,0 +1,40 @@
+import yaml
+
+from app.llm_logging import LLMInteractionLogger, llm_logging_context
+
+
+def test_log_interaction_writes_yaml(tmp_path):
+    log_path = tmp_path / "llm_interactions.yaml"
+    logger = LLMInteractionLogger(log_path=log_path)
+
+    logger.log_interaction(
+        provider="openai",
+        model="gpt-test",
+        prompt={"messages": ["hello"]},
+        response={"content": "world"},
+        metadata={"stage": "unit"},
+    )
+
+    content = log_path.read_text(encoding="utf-8")
+    documents = list(yaml.safe_load_all(content))
+    assert len(documents) == 1
+    entry = documents[0]
+    assert entry["provider"] == "openai"
+    assert entry["model"] == "gpt-test"
+    assert entry["metadata"] == {"stage": "unit"}
+
+
+def test_logging_context_injects_metadata(tmp_path):
+    log_path = tmp_path / "llm_interactions.yaml"
+    logger = LLMInteractionLogger(log_path=log_path)
+
+    with llm_logging_context(component="script", stage="test"):
+        logger.log_interaction(
+            provider="openai",
+            model="gpt-test",
+            prompt="prompt",
+            response="response",
+        )
+
+    documents = list(yaml.safe_load_all(log_path.read_text(encoding="utf-8")))
+    assert documents[0]["context"] == {"component": "script", "stage": "test"}


### PR DESCRIPTION
## Summary
- switch the LLM interaction logger to append YAML multi-document records instead of JSON lines
- update the LLM guardrail documentation to describe the YAML-based logging discipline
- add unit coverage that verifies YAML persistence and contextual metadata injection

## Testing
- pytest tests/unit/test_llm_logging.py

------
https://chatgpt.com/codex/tasks/task_e_68e499f40f6083258483ca941c03caab